### PR TITLE
Change loopback peer dep to "1.x || 2.x"

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "fs-extra": "^0.9.1"
   },
   "peerDependencies": {
-    "loopback": "1.x"
+    "loopback": "1.x || 2.x"
   }
 }


### PR DESCRIPTION
Support the upcoming 2.x version of LoopBack.

The devDependency is intentionally kept at 1.x to ensure the module
supports LoopBack 1.x too.
