### PR TITLE
[2.0] Rework model configuration

### DIFF
--- a/docs/browserify.md
+++ b/docs/browserify.md
@@ -46,7 +46,6 @@ contained in the browser bundle:
 /*-- app.js --*/
 var loopback = require('loopback');
 var boot = require('loopback-boot');
-require('./models');
 
 var app = module.exports = loopback();
 boot(app);

--- a/index.js
+++ b/index.js
@@ -33,9 +33,9 @@ var addInstructionsToBrowserify = require('./lib/bundler');
  * `/boot` subdirectory of the application root directory with `require()`.
  *
  *  **NOTE:** The version 2.0 of loopback-boot changed the way how models
- *  are created. loopback-boot no longer creates the models for you,
- *  the `models.json` file contains only configuration options like
- *  dataSource and extra relations.
+ *  are created. The `models.json` file contains only configuration options like
+ *  dataSource and extra relations. To define a model, create a per-model
+ *  JSON file in `models/` directory.
  *
  *  **NOTE:** mixing `app.boot()` and `app.model(name, config)` in multiple
  *  files may result in models being **undefined** due to race conditions.
@@ -60,6 +60,8 @@ var addInstructionsToBrowserify = require('./lib/bundler');
  * @property {String} [env] Environment type, defaults to `process.env.NODE_ENV`
  * or `development`. Common values are `development`, `staging` and
  * `production`; however the applications are free to use any names.
+ * @property {Array.<String>} [modelSources] List of directories where to look
+ * for files containing model definitions.
  * @end
  *
  * @header bootLoopBackApp(app, [options])

--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -9,32 +9,53 @@ var commondir = require('commondir');
  */
 
 module.exports = function addInstructionsToBrowserify(instructions, bundler) {
-  bundleScripts(instructions.files, bundler);
+  bundleModelScripts(instructions, bundler);
+  bundleOtherScripts(instructions, bundler);
   bundleInstructions(instructions, bundler);
 };
 
-function bundleScripts(files, bundler) {
-  for (var key in files) {
-    var list = files[key];
-    if (!list.length) continue;
+function bundleOtherScripts(instructions, bundler) {
+  for (var key in instructions.files) {
+    addScriptsToBundle(key, instructions.files[key], bundler);
+  }
+}
 
-    var root = commondir(files[key].map(path.dirname));
+function bundleModelScripts(instructions, bundler) {
+  var files = instructions.models
+    .map(function(m) { return m.sourceFile; })
+    .filter(function(f) { return !!f; });
 
-    for (var ix in list) {
-      var filepath = list[ix];
+  var modelToFileMapping = instructions.models
+    .map(function(m) { return files.indexOf(m.sourceFile); });
 
-      // Build a short unique id that does not expose too much
-      // information about the file system, but still preserves
-      // useful information about where is the file coming from.
-      var fileid = 'loopback-boot#' + key + '#' + path.relative(root, filepath);
+  addScriptsToBundle('models', files, bundler);
 
-      // Add the file to the bundle.
-      bundler.require(filepath, { expose: fileid });
+  // Update `sourceFile` properties with the new paths
+  modelToFileMapping.forEach(function(fileIx, modelIx) {
+    if (fileIx === -1) return;
+    instructions.models[modelIx].sourceFile = files[fileIx];
+  });
+}
 
-      // Rewrite the instructions entry with the new id that will be
-      // used to load the file via `require(fileid)`.
-      list[ix] = fileid;
-    }
+function addScriptsToBundle(name, list, bundler) {
+  if (!list.length) return;
+
+  var root = commondir(list.map(path.dirname));
+
+  for (var ix in list) {
+    var filepath = list[ix];
+
+    // Build a short unique id that does not expose too much
+    // information about the file system, but still preserves
+    // useful information about where is the file coming from.
+    var fileid = 'loopback-boot#' + name + '#' + path.relative(root, filepath);
+
+    // Add the file to the bundle.
+    bundler.require(filepath, { expose: fileid });
+
+    // Rewrite the instructions entry with the new id that will be
+    // used to load the file via `require(fileid)`.
+    list[ix] = fileid;
   }
 }
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -42,10 +42,14 @@ module.exports = function compile(options) {
   // require directories
   var bootScripts = findScripts(path.join(appRootDir, 'boot'));
 
+  var modelSources = options.modelSources || ['./models'];
+  var modelInstructions = buildAllModelInstructions(
+    appRootDir, modelsConfig, modelSources);
+
   return {
     app: appConfig,
     dataSources: dataSourcesConfig,
-    models: modelsConfig,
+    models: modelInstructions,
     files: {
       boot: bootScripts
     }
@@ -137,4 +141,112 @@ function tryReadDir() {
   } catch(e) {
     return [];
   }
+}
+
+function buildAllModelInstructions(rootDir, modelsConfig, sources) {
+  var registry = findModelDefinitions(rootDir, sources);
+
+  var modelNamesToBuild = addAllBaseModels(registry, Object.keys(modelsConfig));
+
+  var instructions = modelNamesToBuild
+    .map(function createModelInstructions(name) {
+      var config = modelsConfig[name];
+      var definition = registry[name] || {};
+
+      debug('Using model "%s"\nConfiguration: %j\nDefinition %j',
+        name, config, definition.definition);
+
+      return {
+        name: name,
+        config: config,
+        definition: definition.definition,
+        sourceFile: definition.sourceFile
+      };
+    });
+
+  return sortByInheritance(instructions);
+}
+
+function addAllBaseModels(registry, modelNames) {
+  var result = [];
+  var visited = {};
+
+  while (modelNames.length) {
+    var name = modelNames.shift();
+    result.push(name);
+
+    var definition = registry[name] && registry[name].definition;
+    if (!definition) continue;
+
+    var base = definition.base || definition.options && definition.options.base;
+    if (!base || base in visited) continue;
+
+    visited[base] = true;
+
+    // ignore built-in models like User
+    if (!registry[base]) continue;
+
+    modelNames.push(base);
+  }
+
+  return result;
+}
+
+function sortByInheritance(instructions) {
+  // TODO implement topological sort
+  return instructions.reverse();
+}
+
+function findModelDefinitions(rootDir, sources) {
+  var registry = {};
+
+  sources.forEach(function(src) {
+    var srcDir = path.resolve(rootDir, src);
+    var files = tryReadDir(srcDir);
+    files
+      .filter(function(f) {
+        return f[0] !== '_' && path.extname(f) === '.json';
+      })
+      .forEach(function(f) {
+        var fullPath = path.resolve(srcDir, f);
+        var entry = loadModelDefinition(rootDir, fullPath);
+        var modelName = entry.definition.name;
+        if (!modelName) {
+          debug('Skipping model definition without Model name: %s',
+            path.relative(srcDir, fullPath));
+          return;
+        }
+        registry[modelName] = entry;
+      });
+  });
+
+  return registry;
+}
+
+function loadModelDefinition(rootDir, jsonFile) {
+  var definition = require(jsonFile);
+
+  var sourceFile = path.join(
+    path.dirname(jsonFile),
+    path.basename(jsonFile, path.extname(jsonFile)));
+
+  try {
+    // resolve the file to `.js` or any other supported extension like `.coffee`
+    sourceFile = require.resolve(sourceFile);
+  } catch (err) {
+    debug('Model source code not found: %s - %s', sourceFile, err.code || err);
+    sourceFile = undefined;
+  }
+
+  if (sourceFile === jsonFile)
+    sourceFile = undefined;
+
+  debug('Found model "%s" - %s %s', definition.name,
+    path.relative(rootDir, jsonFile),
+    sourceFile ? path.relative(rootDir, sourceFile) : '(no source file)');
+
+  return {
+    definition: definition,
+    sourceFile: sourceFile
+  };
 }

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -95,12 +95,37 @@ function setupDataSources(app, instructions) {
 }
 
 function setupModels(app, instructions) {
-  forEachKeyedObject(instructions.models, function(key, obj) {
-    var model = loopback.getModel(key);
-    if (!model) {
-      throw new Error('Cannot configure unknown model ' + key);
+  instructions.models.forEach(function(data) {
+    var name = data.name;
+    var model;
+
+    if (!data.definition) {
+      model = loopback.getModel(name);
+      if (!model) {
+        throw new Error('Cannot configure unknown model ' + name);
+      }
+      debug('Configuring existing model %s', name);
+    } else {
+      debug('Creating new model %s %j', name, data.definition);
+      model = loopback.createModel(data.definition);
+      if (data.sourceFile) {
+        debug('Loading customization script %s', data.sourceFile);
+        var code = require(data.sourceFile);
+        if (typeof code === 'function') {
+          debug('Customizing model %s', name);
+          // NOTE model.super_ is set by Node's util.inherits
+          code(model, model.super_);
+        } else {
+          debug('Skipping model file %s - `module.exports` is not a function',
+            data.sourceFile);
+        }
+      }
     }
-    app.model(model, obj);
+
+    // Skip base models that are not exported to the app
+    if (!data.config) return;
+
+    app.model(model, data.config);
   });
 }
 

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -17,6 +17,9 @@ describe('browser support', function() {
 
       // configured in fixtures/browser-app/boot/configure.js
       expect(app.settings).to.have.property('custom-key', 'custom-value');
+      expect(Object.keys(app.models)).to.include('Customer');
+      expect(app.models.Customer.settings)
+        .to.have.property('_customized', 'Customer');
 
       done();
     });
@@ -53,12 +56,17 @@ function executeBundledApp(bundlePath) {
 }
 
 function createBrowserLikeContext() {
-  return vm.createContext({
+  var context = {
     // required by browserify
     XMLHttpRequest: function() { throw new Error('not implemented'); },
 
-    // used by loopback to detect browser runtime
-    window: {},
+    localStorage: {
+      // used by `debug` module
+      debug: process.env.DEBUG
+    },
+
+    // used by `debug` module
+    document: { documentElement: { style: {} } },
 
     // allow the browserified code to log messages
     // call `printContextLogs(context)` to print the accumulated messages
@@ -78,7 +86,12 @@ function createBrowserLikeContext() {
         error: []
       },
     }
-  });
+  };
+
+  // `window` is used by loopback to detect browser runtime
+  context.window = context;
+
+  return vm.createContext(context);
 }
 
 function printContextLogs(context) {

--- a/test/fixtures/browser-app/datasources.json
+++ b/test/fixtures/browser-app/datasources.json
@@ -1,0 +1,5 @@
+{
+  "db": {
+    "connector": "remote"
+  }
+}

--- a/test/fixtures/browser-app/models.json
+++ b/test/fixtures/browser-app/models.json
@@ -1,0 +1,5 @@
+{
+  "Customer": {
+    "dataSource": "db"
+  }
+}

--- a/test/fixtures/browser-app/models/customer.js
+++ b/test/fixtures/browser-app/models/customer.js
@@ -1,0 +1,4 @@
+module.exports = function(Customer, Base) {
+  Customer.settings._customized = 'Customer';
+  Base.settings._customized = 'Base';
+};

--- a/test/fixtures/browser-app/models/customer.json
+++ b/test/fixtures/browser-app/models/customer.json
@@ -1,0 +1,4 @@
+{
+  "name": "Customer",
+  "base": "User"
+}


### PR DESCRIPTION
Rework the way how models are configured, the goal is to allow
loopback-boot to automatically determine the correct order
of the model definitions to ensure base models are defined
before they are extended (see strongloop/loopback#324).
1. The model .js file no longer creates the model, it exports
   a config function instead:
   
   ``` js
   module.exports = function(Car, Base) {
     // Car is the model constructor
     // Base is the parent model (e.g. loopback.PersistedModel)
   
     Car.prototype.honk = function(duration, cb) {
       // make some noise for `duration` seconds
       cb();
     };
   };
   ```
2. The model is created by loopback-boot from model .json file.
   The .js file must have the same base file name.
3. The `boot()` function has a new parameter `modelSources` to
   specify the list of directories where to look for model definitions.
   The parameter defaults to `['./models']`.

As a side effect, only models configured in `models.json` and their
base clases are defined. This should keep the size of the browserified
bundle small, because unused models are not included.

/to @ritch please review
/cc @raymondfeng @kraman 

Note: I have not implemented the topological sort yet, I'll do that in a new pull request once the direction is approved.
