### PR TITLE
compiler: return a clone of instructions

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var cloneDeep = require('lodash.clonedeep');
 var fs = require('fs');
 var path = require('path');
 var ConfigLoader = require('./config-loader');
@@ -43,7 +44,10 @@ module.exports = function compile(options) {
   var modelsScripts = findScripts(path.join(modelsRootDir, 'models'));
   var bootScripts = findScripts(path.join(appRootDir, 'boot'));
 
-  return {
+  // When executor passes the instruction to loopback methods,
+  // loopback modifies the data. Since we are loading the data using `require`,
+  // such change affects also code that calls `require` for the same file.
+  return cloneDeep({
     app: appConfig,
     dataSources: dataSourcesConfig,
     models: modelsConfig,
@@ -51,7 +55,7 @@ module.exports = function compile(options) {
       models: modelsScripts,
       boot: bootScripts
     }
-  };
+  });
 };
 
 function assertIsValidConfig(name, config) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "commondir": "0.0.1",
     "debug": "^0.8.1",
+    "lodash.clonedeep": "^2.4.1",
     "semver": "^2.3.0",
     "underscore": "^1.6.0"
   },

--- a/test/compiler.test.js
+++ b/test/compiler.test.js
@@ -216,5 +216,15 @@ describe('compiler', function() {
 
       expect(instructions.files.models).to.eql([]);
     });
+
+    it('returns a new copy of JSON data', function() {
+      appdir.createConfigFilesSync();
+
+      var instructions = boot.compile(appdir.PATH);
+      instructions.app.modified = true;
+
+      instructions = boot.compile(appdir.PATH);
+      expect(instructions.app).to.not.have.property('modified');
+    });
   });
 });


### PR DESCRIPTION
When executor passes the instruction to loopback methods,
loopback modifies the data. Since we are loading the data using
`require` such changes affects also code that calls
`require` for one of the instructions files.

This change adds a deep clone step to prevent this issue.

/to @ritch please review. I'll port the patch to the master (2.x) branch after this PR is merged.
