### PR TITLE
test: export Int32Array and DataView for browser

### DIFF
--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -68,6 +68,10 @@ function createBrowserLikeContext() {
     // used by `debug` module
     document: { documentElement: { style: {} } },
 
+    // used by crypto-browserify & friends
+    Int32Array: Int32Array,
+    DataView: DataView,
+
     // allow the browserified code to log messages
     // call `printContextLogs(context)` to print the accumulated messages
     console: {


### PR DESCRIPTION
crypto-browserify uses Int32Array, which is not exposed on the VM
context in Node v0.10.

Close #22 

/to @raymondfeng please review
