### PR TITLE
Add support async scripts

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -12,6 +12,7 @@
 "newcap": true,
 "nonew": true,
 "sub": true,
+"unused": "vars",
 "globals": {
   "describe": true,
   "it": true,

--- a/index.js
+++ b/index.js
@@ -75,12 +75,12 @@ var addInstructionsToBrowserify = require('./lib/bundler');
  * @header boot(app, [options])
  */
 
-exports = module.exports = function bootLoopBackApp(app, options) {
+exports = module.exports = function bootLoopBackApp(app, options, callback) {
   // backwards compatibility with loopback's app.boot
   options.env = options.env || app.get('env');
 
   var instructions = compile(options);
-  execute(app, instructions);
+  execute(app, instructions, callback);
 };
 
 /**

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -2,6 +2,7 @@ var assert = require('assert');
 var _ = require('underscore');
 var semver = require('semver');
 var debug = require('debug')('loopback:boot:executor');
+var async = require('async');
 
 /**
  * Execute bootstrap instructions gathered by `boot.compile`.
@@ -12,7 +13,7 @@ var debug = require('debug')('loopback:boot:executor');
  * @header boot.execute(instructions)
  */
 
-module.exports = function execute(app, instructions) {
+module.exports = function execute(app, instructions, callback) {
   patchAppLoopback(app);
   assertLoopBackVersion(app);
 
@@ -24,9 +25,16 @@ module.exports = function execute(app, instructions) {
   setupDataSources(app, instructions);
   setupModels(app, instructions);
 
-  runBootScripts(app, instructions);
-
-  enableAnonymousSwagger(app, instructions);
+  // Run the boot scripts in series synchronously or asynchronously
+  // Please note async supports both styles
+  async.series([
+    function(done) {
+      runBootScripts(app, instructions, done);
+    },
+    function(done) {
+      enableAnonymousSwagger(app, instructions);
+      done();
+    }], callback);
 };
 
 function patchAppLoopback(app) {
@@ -176,13 +184,36 @@ function forEachKeyedObject(obj, fn) {
   });
 }
 
-function runScripts(app, list) {
-  if (!list || !list.length) return;
+function runScripts(app, list, callback) {
+  list = list || [];
+  var functions = [];
   list.forEach(function(filepath) {
+    debug('Requiring script %s', filepath);
     var exports = tryRequire(filepath);
-    if (typeof exports === 'function')
-      exports(app);
+    if (typeof exports === 'function') {
+      debug('Exported function detected %s', filepath);
+      functions.push({
+        path: filepath,
+        func: exports
+      });
+    }
   });
+
+  async.eachSeries(functions, function(f, done) {
+    debug('Running script %s', f.path);
+    if (f.func.length >= 2) {
+      debug('Starting async function %s', f.path);
+      f.func(app, function(err) {
+        debug('Async function finished %s', f.path);
+        done(err);
+      });
+    } else {
+      debug('Starting sync function %s', f.path);
+      f.func(app);
+      debug('Sync function finished %s', f.path);
+      done();
+    }
+  }, callback);
 }
 
 function tryRequire(modulePath) {
@@ -198,8 +229,8 @@ function tryRequire(modulePath) {
   }
 }
 
-function runBootScripts(app, instructions) {
-  runScripts(app, instructions.files.boot);
+function runBootScripts(app, instructions, callback) {
+  runScripts(app, instructions.files.boot, callback);
 }
 
 function enableAnonymousSwagger(app, instructions) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "url": "https://github.com/strongloop/loopback-boot/blob/master/LICENSE"
   },
   "dependencies": {
+    "async": "~0.9.0",
     "commondir": "0.0.1",
     "debug": "^1.0.4",
     "lodash.clonedeep": "^2.4.1",

--- a/test/fixtures/simple-app/boot/bar.js
+++ b/test/fixtures/simple-app/boot/bar.js
@@ -1,0 +1,8 @@
+process.bootFlags.push('barLoaded');
+module.exports = function(app, callback) {
+  process.bootFlags.push('barStarted');
+  process.nextTick(function() {
+    process.bootFlags.push('barFinished');
+    callback();
+  });
+};

--- a/test/fixtures/simple-app/boot/barSync.js
+++ b/test/fixtures/simple-app/boot/barSync.js
@@ -1,0 +1,5 @@
+process.bootFlags.push('barSyncLoaded');
+module.exports = function(app) {
+  process.bootFlags.push('barSyncExecuted');
+};
+

--- a/test/fixtures/simple-app/boot/foo.js
+++ b/test/fixtures/simple-app/boot/foo.js
@@ -1,1 +1,1 @@
-process.loadedFooJS = true;
+process.bootFlags.push('fooLoaded');


### PR DESCRIPTION
/to @bajtos 
/cc @ritch 

The PR adds two enhancements for boot:

Allow boot scripts to be executed asynchronously

> module.exports = function(app, callback) {...}
