### PR TITLE
package: Add `jshint` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
     "underscore": "^1.6.0"
   },
   "devDependencies": {
+    "browserify": "^4.1.8",
+    "fs-extra": "^0.10.0",
+    "jshint": "^2.5.6",
     "loopback": "^1.5.0",
     "mocha": "^1.19.0",
     "must": "^0.12.0",
-    "supertest": "^0.13.0",
-    "fs-extra": "^0.10.0",
-    "browserify": "^4.1.8"
+    "supertest": "^0.13.0"
   }
 }


### PR DESCRIPTION
Remove dependency on a globally installed jshint instance
and fix `npm test` on machines without a global jshint.

Supersedes #47.

/cc @shelbys
