### PR TITLE
wip: Split the boot execution into phases

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -26,13 +26,15 @@ module.exports = function execute(app, instructions, callback) {
     'boot:init',
     'boot:dataSources',
     'boot:models',
+    'boot:middleware',
     'boot:scripts',
-    'boot:enableSwagger'
+    'boot:complete'
   ]);
 
   var initialPhase = app.phase('boot:init');
   var dataSourcePhase = app.phase('boot:dataSources');
   var modelPhase = app.phase('boot:models');
+  var middlewarePhase = app.phase('boot:middleware');
   var scriptPhase = app.phase('boot:scripts');
   var swaggerPhase = app.phase('boot:enableSwagger');
 
@@ -46,16 +48,38 @@ module.exports = function execute(app, instructions, callback) {
     cb();
   });
 
-  // Run the boot scripts in series synchronously or asynchronously
-  // Please note async supports both styles
-  scriptPhase.register(function(cb) {
-    runBootScripts(app, instructions, cb);
+  middlewarePhase.register(function(cb) {
+    var middlewarePhaseOrder = app.get('middlewarePhaseOrder') || [
+      'middleware:init',
+      'middleware:authentication',
+      'middleware:authorization',
+      'middleware:header-processing',
+      'middleware:body-parsing',
+      'middleware:user',
+      'middleware:format-response',
+      'middleware:response-complete'
+    ];
+
+    app.phases.addInOrder(middlewarePhaseOrder);
+
+    app.use(function(req, res, next) {
+      phases.findById('middleware:init').launch({
+        req: req,
+        res: res
+      }, next);
+    });
   });
 
-  swaggerPhase.register(function(cb) {
-    enableAnonymousSwagger(app, instructions);
-    cb();
-  });
+  // Run the boot scripts in series synchronously or asynchronously
+  // Please note async supports both styles
+  scriptPhase
+    .register(function(cb) {
+      runBootScripts(app, instructions, cb);
+    })
+    .after(function(cb) {
+      enableAnonymousSwagger(app, instructions);
+      cb();
+    });
 
   initialPhase.launch(callback);
 };


### PR DESCRIPTION
For now this is an example usage of phases... This will allow you to do neat stuff like this:

``` js
app.phase('boot:models').after(function(cb) {
  // models have now been defined
  console.log(app.models());
  cb();
});
```

or in the middleware phases....

``` js
app.phase('middleware:authentication').after(function(cb) {
  // the user making the request
  this.req.accessToken.user(function(err, user) {
    console.log(user.email);
    cb();
  });
});
```

**Before We Can Merge**
- [ ] tests
- [ ] loopback-phase released as 1.0.0
- [ ] loopback's `app.phase()` support
- [ ] loopback's `app.phases` support

/to @bajtos please review
/cc @raymondfeng 
