### PR TITLE
Fix the test for built-in models on Windows

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -3,6 +3,7 @@ var _ = require('underscore');
 var semver = require('semver');
 var debug = require('debug')('loopback:boot:executor');
 var async = require('async');
+var path = require('path');
 
 /**
  * Execute bootstrap instructions gathered by `boot.compile`.
@@ -181,13 +182,19 @@ function defineModels(app, instructions) {
   });
 }
 
+// Regular expression to match built-in loopback models
+var LOOPBACK_MODEL_REGEXP = new RegExp(
+  ['', 'node_modules', 'loopback', '[^\\/\\\\]+', 'models', '[^\\/\\\\]+\\.js$']
+    .join('\\' + path.sep));
+
 function isBuiltinLoopBackModel(app, data) {
   // 1. Built-in models are exposed on the loopback object
   if (!app.loopback[data.name]) return false;
 
   // 2. Built-in models have a script file `loopback/{facet}/models/{name}.js`
-  return data.sourceFile &&
-    /node_modules\/loopback\/[^\/]+\/models\/[^\/]+\.js$/.test(data.sourceFile);
+  var srcFile = data.sourceFile;
+  return srcFile &&
+    LOOPBACK_MODEL_REGEXP.test(srcFile);
 }
 
 function forEachKeyedObject(obj, fn) {


### PR DESCRIPTION
/to @bajtos 

The PR fixes how built-in models are checked on Windows where the file path separator is NOT /. 

Please note no unit test is added because one of the existing tests is failing on Windows before this patch.

See https://github.com/strongloop/loopback/issues/756
