### PR TITLE
Load middleware and phases from `middleware.json`

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,8 @@ var addInstructionsToBrowserify = require('./lib/bundler');
  * `production`; however the applications are free to use any names.
  * @property {Array.<String>} [modelSources] List of directories where to look
  * for files containing model definitions.
+ * @property {Object} [middleware] Middleware configuration to use instead
+ * of `{appRootDir}/middleware.json`
  * @property {Array.<String>} [bootDirs] List of directories where to look
  * for boot scripts.
  * @property {Array.<String>} [bootScripts] List of script files to execute

--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 var commondir = require('commondir');
+var cloneDeep = require('lodash.clonedeep');
 
 /**
  * Add boot instructions to a browserify bundler.
@@ -60,6 +61,17 @@ function addScriptsToBundle(name, list, bundler) {
 }
 
 function bundleInstructions(instructions, bundler) {
+  instructions = cloneDeep(instructions);
+
+  var hasMiddleware = instructions.middleware.phases.length ||
+    instructions.middleware.middleware.length;
+  if (hasMiddleware) {
+    console.warn(
+      'Discarding middleware instructions,' +
+      ' loopback client does not support middleware.');
+  }
+  delete instructions.middleware;
+
   var instructionsString = JSON.stringify(instructions, null, 2);
 
   /* The following code does not work due to a bug in browserify

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -44,6 +44,14 @@ module.exports = function compile(options) {
     ConfigLoader.loadDataSources(dsRootDir, env);
   assertIsValidConfig('data source', dataSourcesConfig);
 
+  // not configurable yet
+  var middlewareRootDir = appRootDir;
+
+  var middlewareConfig = options.middleware ||
+    ConfigLoader.loadMiddleware(middlewareRootDir, env);
+  var middlewareInstructions =
+    buildMiddlewareInstructions(middlewareRootDir, middlewareConfig);
+
   // require directories
   var bootDirs = options.bootDirs || []; // precedence
   bootDirs = bootDirs.concat(path.join(appRootDir, 'boot'));
@@ -67,6 +75,7 @@ module.exports = function compile(options) {
     config: appConfig,
     dataSources: dataSourcesConfig,
     models: modelInstructions,
+    middleware: middlewareInstructions,
     files: {
       boot: bootScripts
     }
@@ -336,5 +345,48 @@ function loadModelDefinition(rootDir, jsonFile, allFiles) {
   return {
     definition: definition,
     sourceFile: sourceFile
+  };
+}
+
+function buildMiddlewareInstructions(rootDir, config) {
+  var phasesNames = Object.keys(config);
+  var middlewareList = [];
+  phasesNames.forEach(function(phase) {
+    var phaseConfig = config[phase];
+    Object.keys(phaseConfig).forEach(function(middleware) {
+      var start = middleware.substring(0, 2);
+      var sourceFile = start !== './' && start !== '..' ?
+        middleware :
+        path.resolve(rootDir, middleware);
+
+      var allConfigs = phaseConfig[middleware];
+      if (!Array.isArray(allConfigs))
+        allConfigs = [allConfigs];
+
+      allConfigs.forEach(function(config) {
+        var middlewareConfig = cloneDeep(config);
+        middlewareConfig.phase = phase;
+
+        middlewareList.push({
+          sourceFile: require.resolve(sourceFile),
+          config: middlewareConfig
+        });
+      });
+    });
+  });
+
+  var flattenedPhaseNames = phasesNames
+    .map(function getBaseName(name) {
+      return name.replace(/:[^:]+$/, '');
+    })
+    .filter(function differsFromPreviousItem(value, ix, source) {
+      // Skip duplicate entries. That happens when
+      // `name:before` and `name:after` are both translated to `name`
+      return ix === 0 || value !== source[ix - 1];
+    });
+
+  return {
+    phases: flattenedPhaseNames,
+    middleware: middlewareList
   };
 }

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -34,6 +34,16 @@ ConfigLoader.loadModels = function(rootDir, env) {
   return tryReadJsonConfig(rootDir, 'model-config') || {};
 };
 
+/**
+ * Load middleware config from `middleware.json` and friends.
+ * @param {String} rootDir Directory where to look for files.
+ * @param {String} env Environment, usually `process.env.NODE_ENV`
+ * @returns {Object}
+ */
+ConfigLoader.loadMiddleware = function(rootDir, env) {
+  return loadNamed(rootDir, env, 'middleware', mergeMiddlewareConfig);
+};
+
 /*-- Implementation --*/
 
 /**
@@ -123,6 +133,32 @@ function mergeAppConfig(target, config, fileName) {
   var err = mergeObjects(target, config);
   if (err) {
     throw new Error('Cannot apply ' + fileName + ': ' + err);
+  }
+}
+
+function mergeMiddlewareConfig(target, config, fileName) {
+  var err;
+  for (var phase in config) {
+    if (phase in target) {
+      err = mergePhaseConfig(target[phase], config[phase], phase);
+    } else {
+      err = 'The phase "' + phase + '" is not defined in the main config.';
+    }
+    if (err)
+      throw new Error('Cannot apply ' + fileName + ': ' + err);
+  }
+}
+
+function mergePhaseConfig(target, config, phase) {
+  var err;
+  for (var middleware in config) {
+    if (middleware in target) {
+      err = mergeObjects(target[middleware], config[middleware]);
+    } else {
+      err = 'The middleware "' + middleware + '" in phase "' + phase + '"' +
+        'is not defined in the main config.';
+    }
+    if (err) return err;
   }
 }
 

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -26,6 +26,7 @@ module.exports = function execute(app, instructions, callback) {
 
   setupDataSources(app, instructions);
   setupModels(app, instructions);
+  setupMiddleware(app, instructions);
 
   // Run the boot scripts in series synchronously or asynchronously
   // Please note async supports both styles
@@ -248,6 +249,30 @@ function tryRequire(modulePath) {
     console.error('failed to require "%s"', modulePath);
     throw e;
   }
+}
+
+function setupMiddleware(app, instructions) {
+  if (!instructions.middleware) {
+    // the browserified client does not support middleware
+    return;
+  }
+
+  var phases = instructions.middleware.phases;
+  assert(Array.isArray(phases),
+    'instructions.middleware.phases must be an array');
+
+  var middleware = instructions.middleware.middleware;
+  assert(Array.isArray(middleware),
+    'instructions.middleware.middleware must be an object');
+
+  debug('Defining middleware phases %j', phases);
+  app.defineMiddlewarePhases(phases);
+
+  middleware.forEach(function(data) {
+    debug('Configuring middleware %j', data.sourceFile);
+    var factory = require(data.sourceFile);
+    app.middlewareFromConfig(factory, data.config);
+  });
 }
 
 function runBootScripts(app, instructions, callback) {

--- a/test/fixtures/simple-app/middleware.json
+++ b/test/fixtures/simple-app/middleware.json
@@ -1,0 +1,7 @@
+{
+  "initial": {
+    "../../helpers/push-name-middleware": {
+      "params": "custom-middleware"
+    }
+  }
+}

--- a/test/helpers/push-name-middleware.js
+++ b/test/helpers/push-name-middleware.js
@@ -1,0 +1,8 @@
+module.exports = function(name) {
+  return function(req, res, next) {
+    req._names = req._names || [];
+    req._names.push(name);
+    res.setHeader('names', req._names.join(','));
+    next();
+  };
+};


### PR DESCRIPTION
Sample JSON:

```
    {
      "routes:before": {
        "morgan": {
          "params": ["dev"]
        }
      },
      "routes": {
        "loopback/server/middleware/rest": {
        }
      },
      "subapps": {
        "./adminer": {
        },
      }
    }
```

The JSON file can be customized using the usual conventions:
- middleware.local.{js|json}
- middleware.{env}.{js|json}

It is also possible to mount the same middleware in the same phase
multiple times with different configuration.

Example config:

```
{
  "auth": {
    "oauth2": [
      {
        "params": "first"
      },
      {
        "params": "second"
      }
    ]
  },
});
```

A part of https://github.com/strongloop/loopback-boot/issues/44

/to @raymondfeng please review
/cc @ritch
