### PR TITLE
#68 - Implement shorthand notation for middleware paths

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -354,23 +354,24 @@ function buildMiddlewareInstructions(rootDir, config) {
   phasesNames.forEach(function(phase) {
     var phaseConfig = config[phase];
     Object.keys(phaseConfig).forEach(function(middleware) {
-      var start = middleware.substring(0, 2);
-      var sourceFile = start !== './' && start !== '..' ?
-        middleware :
-        path.resolve(rootDir, middleware);
-
       var allConfigs = phaseConfig[middleware];
       if (!Array.isArray(allConfigs))
         allConfigs = [allConfigs];
 
       allConfigs.forEach(function(config) {
+        var resolved = resolveMiddlewarePath(rootDir, middleware);
+
         var middlewareConfig = cloneDeep(config);
         middlewareConfig.phase = phase;
 
-        middlewareList.push({
-          sourceFile: require.resolve(sourceFile),
+        var item = {
+          sourceFile: resolved.sourceFile,
           config: middlewareConfig
-        });
+        };
+        if (resolved.fragment) {
+          item.fragment = resolved.fragment;
+        }
+        middlewareList.push(item);
       });
     });
   });
@@ -389,4 +390,61 @@ function buildMiddlewareInstructions(rootDir, config) {
     phases: flattenedPhaseNames,
     middleware: middlewareList
   };
+}
+
+function resolveMiddlewarePath(rootDir, middleware) {
+  var resolved = {};
+
+  var segments = middleware.split('#');
+  var pathName = segments[0];
+  var fragment = segments[1];
+
+  if (fragment) {
+    resolved.fragment = fragment;
+  }
+
+  if (pathName.indexOf('./') === 0 || pathName.indexOf('../') === 0) {
+    // Relative path
+    pathName = path.resolve(rootDir, pathName);
+  }
+
+  if (!fragment) {
+    resolved.sourceFile = require.resolve(pathName);
+    return resolved;
+  }
+
+  var err;
+
+  // Try to require the module and check if <module>.<fragment> is a valid
+  // function
+  var m = require(pathName);
+  if (typeof m[fragment] === 'function') {
+    resolved.sourceFile = require.resolve(pathName);
+    return resolved;
+  }
+
+  /*
+   * module/server/middleware/fragment
+   * module/middleware/fragment
+   */
+  var candidates = [
+    pathName + '/server/middleware/' + fragment,
+    pathName + '/middleware/' + fragment,
+    // TODO: [rfeng] Should we support the following flavors?
+    // pathName + '/lib/' + fragment,
+    // pathName + '/' + fragment
+  ];
+
+  for (var ix in candidates) {
+    try {
+      resolved.sourceFile = require.resolve(candidates[ix]);
+      delete resolved.fragment;
+      return resolved;
+    }
+    catch (e) {
+      // Report the error for the first candidate when no candidate matches
+      if (!err) err = e;
+    }
+  }
+  throw err;
 }

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -257,7 +257,8 @@ function setupMiddleware(app, instructions) {
     return;
   }
 
-  var phases = instructions.middleware.phases;
+  // Phases can be empty
+  var phases = instructions.middleware.phases || [];
   assert(Array.isArray(phases),
     'instructions.middleware.phases must be an array');
 
@@ -269,8 +270,14 @@ function setupMiddleware(app, instructions) {
   app.defineMiddlewarePhases(phases);
 
   middleware.forEach(function(data) {
-    debug('Configuring middleware %j', data.sourceFile);
+    debug('Configuring middleware %j%s', data.sourceFile,
+        data.fragment ? ('#' + data.fragment) : '');
     var factory = require(data.sourceFile);
+    if (data.fragment) {
+      factory = factory[data.fragment];
+    }
+    assert(typeof factory === 'function',
+      'Middleware factory must be a function');
     app.middlewareFromConfig(factory, data.config);
   });
 }

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -375,6 +375,34 @@ describe('executor', function() {
       });
   });
 
+  it('configures middleware using shortform', function(done) {
+
+    boot.execute(app, someInstructions({
+      middleware: {
+        middleware: [
+          {
+            sourceFile: require.resolve('loopback'),
+            fragment: 'static',
+            config: {
+              phase: 'files',
+              params: path.join(__dirname, './fixtures/simple-app/client/')
+            }
+          }
+        ]
+      }
+    }));
+
+    supertest(app)
+      .get('/')
+      .end(function(err, res) {
+        if (err) return done(err);
+        expect(res.text).to.eql('<!DOCTYPE html>\n<html>\n<head lang="en">\n' +
+          '    <meta charset="UTF-8">\n    <title>simple-app</title>\n' +
+          '</head>\n<body>\n<h1>simple-app</h1>\n</body>\n</html>');
+        done();
+      });
+  });
+
   it('configures middleware (end-to-end)', function(done) {
     boot.execute(app, simpleAppInstructions());
 

--- a/test/fixtures/simple-app/client/index.html
+++ b/test/fixtures/simple-app/client/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+    <title>simple-app</title>
+</head>
+<body>
+<h1>simple-app</h1>
+</body>
+</html>

--- a/test/fixtures/simple-app/middleware/index.js
+++ b/test/fixtures/simple-app/middleware/index.js
@@ -1,0 +1,8 @@
+exports.myMiddleware = function(name) {
+  return function(req, res, next) {
+    req._names = req._names || [];
+    req._names.push(name);
+    res.setHeader('names', req._names.join(','));
+    next();
+  };
+};

--- a/test/fixtures/simple-app/node_modules/my-module/index.js
+++ b/test/fixtures/simple-app/node_modules/my-module/index.js
@@ -1,0 +1,7 @@
+/**
+ * Exporting a middleware as a property of the main module
+ */
+exports.myMiddleware = function(req, res, next) {
+  res.setHeader('X-MY-MIDDLEWARE', 'myMiddleware');
+  next();
+};

--- a/test/fixtures/simple-app/node_modules/my-module/package.json
+++ b/test/fixtures/simple-app/node_modules/my-module/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "my-module",
+  "version": "1.0.0",
+  "description": "my-module",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/test/helpers/appdir.js
+++ b/test/helpers/appdir.js
@@ -42,8 +42,12 @@ appdir.writeConfigFileSync = function(name, json) {
 };
 
 appdir.writeFileSync = function(name, content) {
-  var filePath = path.resolve(PATH, name);
+  var filePath = this.resolve(name);
   fs.mkdirsSync(path.dirname(filePath));
   fs.writeFileSync(filePath, content, 'utf-8');
   return filePath;
+};
+
+appdir.resolve = function(name) {
+  return path.resolve(PATH, name);
 };


### PR DESCRIPTION
When the middleware name (path) is in the format {module}/{filename},
loopback-boot resolves the path by trying multiple locations and
using the first one that exists:
- {module}/{filename} - the path as supplied,
   -> e.g. loopback/rest
- {module}/middleware/{filename}
  -> e.g. loopback/middleware/rest
- {module}/server/middleware/{filename}
  -> e.g. loopback/server/middleware/rest

Values in any other format will bypass this resolution algorithm and
they will be used in the original form:
- a full path in a module: loopback/server/middleware/rest
- a relative path: ./middleware/custom, ./custom, ../logger
- an absolute path: /usr/local/lib/node_modules/compression

Close #68

/to @ritch please review
/cc @raymondfeng 
