### PR TITLE
compiler: resolve paths in middleware params

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -364,6 +364,11 @@ function buildMiddlewareInstructions(rootDir, config) {
         var middlewareConfig = cloneDeep(config);
         middlewareConfig.phase = phase;
 
+        if (middlewareConfig.params) {
+          middlewareConfig.params = resolveMiddlewareParams(
+            rootDir, middlewareConfig.params);
+        }
+
         var item = {
           sourceFile: resolved.sourceFile,
           config: middlewareConfig
@@ -447,4 +452,17 @@ function resolveMiddlewarePath(rootDir, middleware) {
     }
   }
   throw err;
+}
+
+// Match values starting with `$!./` or `$!../`
+var MIDDLEWARE_PATH_PARAM_REGEX = /^\$!(\.\/|\.\.\/)/;
+
+function resolveMiddlewareParams(rootDir, params) {
+  return cloneDeep(params, function resolvePathParam(value) {
+    if (typeof value === 'string' && MIDDLEWARE_PATH_PARAM_REGEX.test(value)) {
+      return path.resolve(rootDir, value.slice(2));
+    } else {
+      return undefined; // no change
+    }
+  });
 }


### PR DESCRIPTION
Introduce a convention for specifying relative paths in middleware params: values prefixed with `$!` and starting with `./` or `../` are resolved relatively to `middleware.json`.

Example (`server/middleware.json`)

```
{
  "files": {
    "loopback#static": {
      "params": "$!../client"
      // resolved to `client`
    },
    "loopback#static": {
      "params": "$!./public"
      // resolved to `server/public`
    }
  }
}
```

/to @ritch @raymondfeng please review, especially whether the prefix value makes sense to you too. It was inspired by hashbang (`#!`) used by client-side MVC frameworks.

I have discovered this use case while reworking the template scaffolded by `slc loopback` as part of  strongloop/loopback-workspace#167
