### PR TITLE
Filter boot scripts for duplicates on compile.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,5 +1,6 @@
+var _ = require('lodash');
 var assert = require('assert');
-var cloneDeep = require('lodash').cloneDeep;
+var cloneDeep = _.cloneDeep;
 var fs = require('fs');
 var path = require('path');
 var toposort = require('toposort');
@@ -77,7 +78,7 @@ module.exports = function compile(options) {
     models: modelInstructions,
     middleware: middlewareInstructions,
     files: {
-      boot: bootScripts
+      boot: _.uniq(bootScripts)
     }
   });
 };


### PR DESCRIPTION
This prevents bootScripts from being run twice when using
bootScripts option to define boot script order.