### PR TITLE
workaround for REST API root "/" not handled properly #48 in loopback-explorer

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -129,8 +129,12 @@ function setApiRoot(app, instructions) {
   assert(restApiRoot !== undefined, 'app.restBasePath is required');
   assert(typeof restApiRoot === 'string',
     'app.restApiRoot must be a string');
-  assert(/^\//.test(restApiRoot),
-    'app.restApiRoot must start with "/"');
+  if(restApiRoot=='/'){
+    restApiRoot = ''
+  }else{
+    assert(/^\//.test(restApiRoot),
+      'app.restApiRoot must start with "/"');
+  }
   app.set('restApiRoot', restApiRoot);
 }
 


### PR DESCRIPTION
see [BUG in loopback-explorer for further notice](https://github.com/strongloop/loopback-explorer/issues/48)