### PR TITLE
Don't swallow error when a sub-dependency doesn't resolve.

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -224,7 +224,7 @@ function runScripts(app, list, callback) {
   var functions = [];
   list.forEach(function(filepath) {
     debug('Requiring script %s', filepath);
-    var exports = tryRequire(filepath);
+    var exports = require(filepath);
     if (typeof exports === 'function') {
       debug('Exported function detected %s', filepath);
       functions.push({
@@ -249,19 +249,6 @@ function runScripts(app, list, callback) {
       done();
     }
   }, callback);
-}
-
-function tryRequire(modulePath) {
-  try {
-    return require.apply(this, arguments);
-  } catch (e) {
-    if (e.code === 'MODULE_NOT_FOUND') {
-      debug('Warning: cannot require %s - module not found.', modulePath);
-      return undefined;
-    }
-    console.error('failed to require "%s"', modulePath);
-    throw e;
-  }
 }
 
 function setupMiddleware(app, instructions) {

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -175,6 +175,17 @@ describe('executor', function() {
     expect(app.models.Customer._modelsWhenAttached).to.include('UniqueName');
   });
 
+  it('throws on bad require() call inside boot script', function() {
+    var file = appdir.writeFileSync('boot/badScript.js',
+      'require("doesnt-exist"); module.exports = {};');
+
+    function doBoot() {
+      boot.execute(app, someInstructions({ files: { boot: [file] } }));
+    }
+
+    expect(doBoot).to.throw(/Cannot find module \'doesnt-exist\'/);
+  });
+
   it('instantiates data sources', function() {
     boot.execute(app, dummyInstructions);
     assert(app.dataSources);


### PR DESCRIPTION
This prevents an occurence where an error is completely swallowed if a script
required by loopback-boot has a bad require() call. The script is never ran
but execution continues.

I had a situation where a typo caused a model file to be unloaded, and there was
absolutely no indication this was happening until I tried to call a method via the REST 
adapter and got a message that the sharedClass had no method by that name.

This patch only swallows the error if the actual module we're trying to require
is missing, it does not swallow if a sub-require fails.

It would be nice to merge this into the 1.x branch as well.
