### PR TITLE
Fix "incompatible loopback version" check & msg

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -4,6 +4,7 @@ var semver = require('semver');
 var debug = require('debug')('loopback:boot:executor');
 var async = require('async');
 var path = require('path');
+var format = require('util').format;
 
 /**
  * Execute bootstrap instructions gathered by `boot.compile`.
@@ -73,12 +74,17 @@ function assertLoopBackVersion(app) {
   var RANGE = '1.x || 2.x';
 
   var loopback = app.loopback;
-  if (!semver.satisfies(loopback.version || '1.0.0', RANGE)) {
-    throw new Error(
-        'The `app` is powered by an incompatible loopback version %s. ' +
-        'Supported versions: %s',
-        loopback.version || '(unknown)',
+  // remove any pre-release tag from the version string,
+  // because semver has special treatment of pre-release versions,
+  // while loopback-boot treats pre-releases the same way as regular versions
+  var version = (loopback.version || '1.0.0').replace(/-.*$/, '');
+  if (!semver.satisfies(version, RANGE)) {
+    var msg = format(
+      'The `app` is powered by an incompatible loopback version %s. ' +
+      'Supported versions: %s',
+      loopback.version || '(unknown)',
       RANGE);
+    throw new Error(msg);
   }
 }
 


### PR DESCRIPTION
Use `util.format` to build the error message, `Error` constructors
does not support placeholders like `%s`.

Detect pre-release versions and handle them in the same way as regular
releases.

/to @ritch or @raymondfeng please review