### PR TITLE
Backport PR #88 to 1.x branch.

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -1,7 +1,6 @@
 var assert = require('assert');
 var _ = require('underscore');
 var semver = require('semver');
-var debug = require('debug')('loopback:boot:executor');
 
 /**
  * Execute bootstrap instructions gathered by `boot.compile`.
@@ -146,7 +145,7 @@ function forEachKeyedObject(obj, fn) {
 function runScripts(app, list) {
   if (!list || !list.length) return;
   list.forEach(function(filepath) {
-    var exports = tryRequire(filepath);
+    var exports = require(filepath);
     if (isFunctionNotModelCtor(exports, app.loopback.Model))
       exports(app);
   });
@@ -155,19 +154,6 @@ function runScripts(app, list) {
 function isFunctionNotModelCtor(fn, Model) {
   return typeof fn === 'function' &&
     !(fn.prototype instanceof Model);
-}
-
-function tryRequire(modulePath) {
-  try {
-    return require.apply(this, arguments);
-  } catch(e) {
-    if(e.code === 'MODULE_NOT_FOUND') {
-      debug('Warning: cannot require %s - module not found.', modulePath);
-      return undefined;
-    }
-    console.error('failed to require "%s"', modulePath);
-    throw e;
-  }
 }
 
 // Deprecated, will be removed soon

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -183,6 +183,17 @@ describe('executor', function() {
     expect(app.fnCalled, 'exported fn was called').to.be.true();
   });
 
+  it('throws on bad require() call inside model', function() {
+    var file = appdir.writeFileSync('models/BadCustomer.js',
+      'require("doesnt-exist"); module.exports = {};');
+
+    function doBoot() {
+      boot.execute(app, someInstructions({ files: { models: [ file ] } }));
+    }
+
+    expect(doBoot).to.throw(/Cannot find module \'doesnt-exist\'/);
+  });
+
   it('does not call Model ctor exported by models/model.json', function() {
     var file = appdir.writeFileSync('models/model.js',
         'var loopback = require("loopback");\n' +


### PR DESCRIPTION
This fix is more critical for the 1.x branch than the master branch, as `tryRequire` was surrounding all scripts, not just explicit `boot` scripts. There is a lot more potential for this bug to bite a user in 1.x.

See #88