### PR TITLE
Save instructions.json in root dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.swo
 *.iml
 node_modules
+generated-instructions.json
 checkstyle.xml
 loopback-boot-*.tgz
 /test/sandbox/

--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -94,7 +94,7 @@ function bundleInstructions(instructions, bundler) {
   // Write the instructions to a file in our node_modules folder.
   // The location should not really matter as long as it is .gitignore-ed
   var instructionsFile = path.resolve(__dirname,
-    '..', 'node_modules', 'instructions.json');
+    '..', 'generated-instructions.json');
 
   fs.writeFileSync(instructionsFile, instructionsString, 'utf-8');
   bundler.require(instructionsFile, { expose: 'loopback-boot#instructions' });


### PR DESCRIPTION
Saving instructions in node_modules dir causes complaints and missing files
fixes https://github.com/strongloop/loopback-boot/issues/94