### PR TITLE
Refactor unit test assertions to be more specific

### DIFF
--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -57,8 +57,8 @@ describe('executor', function() {
       expect(app.booting).to.be.undefined();
       boot.execute(app, simpleAppInstructions(), function(err) {
         expect(err).to.be.undefined();
-        expect(process.bootingFlagSet).to.be.ok();
-        expect(app.booting).to.not.be.ok();
+        expect(process.bootingFlagSet).to.be.true();
+        expect(app.booting).to.be.false();
         done();
       });
     });


### PR DESCRIPTION
- Change `process.bootingFlagSet` assertion from `ok()` to `true()`
- Change `app.booting` assertion from `not.be.ok()` to `false()`

Connected to #97 