### PR TITLE
Extend options arg to support custom model definitions

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -265,6 +265,24 @@ function sortByInheritance(instructions) {
     });
 }
 
+/**
+ * Returns matching files with a supported `sourceFile` extension like `.js` or `.coffee`
+ * @param allFiles {Array}
+ * @param basename {string}
+ * @returns {Array}
+ */
+function filterValidSourceFiles(allFiles, basename) {
+  var base, ext, validFileType;
+  return allFiles
+    .filter(function(f) {
+      ext = path.extname(f);
+      base = path.basename(f, ext);
+      validFileType = (ext !== '.node') && (ext !== '.json') &&
+      ((typeof require.extensions[ext]) === 'function');
+      return validFileType && (base === basename);
+    });
+}
+
 function verifyModelDefinitions(rootDir, modelDefinitions) {
   if (!modelDefinitions || modelDefinitions.length < 1) {
     return undefined;
@@ -274,7 +292,13 @@ function verifyModelDefinitions(rootDir, modelDefinitions) {
   modelDefinitions.forEach(function(definition, idx) {
     try {
       var fullPath = path.resolve(rootDir, definition.sourceFile);
-      definition.sourceFile = require.resolve(fullPath);
+      var basename = path.basename(fullPath, path.extname(fullPath));
+      var files = tryReadDir(path.dirname(fullPath));
+      var sourceFile = filterValidSourceFiles(files, basename)[0];
+
+      definition.sourceFile = path.join(path.dirname(fullPath), sourceFile);
+      definition.sourceFile = require.resolve(definition.sourceFile);
+
     } catch (err) {
       debug('Model source code not found: %s - %s', definition.sourceFile, err.code || err);
       definition.sourceFile = undefined;
@@ -362,17 +386,7 @@ function loadModelDefinition(rootDir, jsonFile, allFiles) {
   var basename = path.basename(jsonFile, path.extname(jsonFile));
 
   // find a matching file with a supported extension like `.js` or `.coffee`
-  var base;
-  var ext;
-  var validFileType;
-  var sourceFile = allFiles
-    .filter(function(f) {
-      ext = path.extname(f);
-      base = path.basename(f, ext);
-      validFileType = (ext !== '.node') && (ext !== '.json') &&
-        ((typeof require.extensions[ext]) === 'function');
-      return validFileType && (base === basename);
-    })[0];
+  var sourceFile = filterValidSourceFiles(allFiles, basename)[0];
 
   try {
     sourceFile = path.join(path.dirname(jsonFile), sourceFile);

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -290,17 +290,22 @@ function verifyModelDefinitions(rootDir, modelDefinitions) {
 
   var registry = {};
   modelDefinitions.forEach(function(definition, idx) {
-    try {
-      var fullPath = path.resolve(rootDir, definition.sourceFile);
-      var basename = path.basename(fullPath, path.extname(fullPath));
-      var files = tryReadDir(path.dirname(fullPath));
-      var sourceFile = filterValidSourceFiles(files, basename)[0];
+    if (definition.sourceFile) {
+      try {
+        var fullPath = path.resolve(rootDir, definition.sourceFile);
+        var basename = path.basename(fullPath, path.extname(fullPath));
+        var files = tryReadDir(path.dirname(fullPath));
+        var sourceFile = filterValidSourceFiles(files, basename)[0];
 
-      definition.sourceFile = path.join(path.dirname(fullPath), sourceFile);
-      definition.sourceFile = require.resolve(definition.sourceFile);
+        definition.sourceFile = path.join(path.dirname(fullPath), sourceFile);
+        definition.sourceFile = require.resolve(definition.sourceFile);
 
-    } catch (err) {
-      debug('Model source code not found: %s - %s', definition.sourceFile, err.code || err);
+      } catch (err) {
+        debug('Model source code not found: %s - %s', definition.sourceFile, err.code || err);
+        definition.sourceFile = undefined;
+      }
+    }
+    else {
       definition.sourceFile = undefined;
     }
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -76,8 +76,10 @@ module.exports = function compile(options) {
   delete modelsConfig._meta;
 
   var modelSources = options.modelSources || modelsMeta.sources || ['./models'];
+  var modelDefinitions = options.modelDefinitions || undefined;
+
   var modelInstructions = buildAllModelInstructions(
-    modelsRootDir, modelsConfig, modelSources);
+    modelsRootDir, modelsConfig, modelSources, modelDefinitions);
 
   // When executor passes the instruction to loopback methods,
   // loopback modifies the data. Since we are loading the data using `require`,
@@ -181,8 +183,8 @@ function tryReadDir() {
   }
 }
 
-function buildAllModelInstructions(rootDir, modelsConfig, sources) {
-  var registry = findModelDefinitions(rootDir, sources);
+function buildAllModelInstructions(rootDir, modelsConfig, sources, modelDefinitions) {
+  var registry = verifyModelDefinitions(rootDir, modelDefinitions) || findModelDefinitions(rootDir, sources);
 
   var modelNamesToBuild = addAllBaseModels(registry, Object.keys(modelsConfig));
 
@@ -261,6 +263,36 @@ function sortByInheritance(instructions) {
     .filter(function(inst) {
       return !!inst;
     });
+}
+
+function verifyModelDefinitions(rootDir, modelDefinitions) {
+  if (!modelDefinitions || modelDefinitions.length < 1) {
+    return undefined;
+  }
+
+  var registry = {};
+  modelDefinitions.forEach(function(definition, idx) {
+    try {
+      var fullPath = path.resolve(rootDir, definition.sourceFile);
+      definition.sourceFile = require.resolve(fullPath);
+    } catch (err) {
+      debug('Model source code not found: %s - %s', definition.sourceFile, err.code || err);
+      definition.sourceFile = undefined;
+    }
+
+    debug('Found model "%s" - %s %s', definition.definition.name,
+      'from options',
+      definition.sourceFile ? path.relative(rootDir, definition.sourceFile) : '(no source file)');
+
+    var modelName = definition.definition.name;
+    if (!modelName) {
+      debug('Skipping model definition without Model name (from options.modelDefinitions @ index %s)', idx);
+      return;
+    }
+    registry[modelName] = definition;
+  });
+
+  return registry;
 }
 
 function findModelDefinitions(rootDir, sources) {

--- a/test/compiler.test.js
+++ b/test/compiler.test.js
@@ -100,6 +100,72 @@ describe('compiler', function() {
         expect(instruction.models[0].sourceFile).to.equal(undefined);
       });
 
+      it('should load coffeescript models', function() {
+        require('coffee-script/register');
+
+        appdir.writeFileSync('custom-models/coffee-model-with-definitions.coffee', '');
+        var instruction = boot.compile({
+          appRootDir: appdir.PATH,
+          models: {
+            'coffee-model-with-definitions': {
+              dataSource: 'the-db'
+            }
+          },
+          modelDefinitions: [
+            {
+              definition: {
+                name: 'coffee-model-with-definitions'
+              },
+              sourceFile: path.join(appdir.PATH, 'custom-models', 'coffee-model-with-definitions.coffee')
+            }
+          ],
+          dataSources: dataSources
+        });
+        expect(instruction.models[0].name).to.equal('coffee-model-with-definitions');
+        expect(instruction.models[0].definition).not.to.equal(undefined);
+        expect(instruction.models[0].sourceFile).not.to.equal(undefined);
+      });
+
+      it('should handle sourceFile path without extension.', function() {
+        require('coffee-script/register');
+
+        appdir.writeFileSync('custom-models/coffee-model-without-ext.coffee', '');
+        appdir.writeFileSync('custom-models/js-model-without-ext.js', '');
+        var instruction = boot.compile({
+          appRootDir: appdir.PATH,
+          models: {
+            'coffee-model-without-ext': {
+              dataSource: 'the-db'
+            },
+            'js-model-without-ext': {
+              dataSource: 'the-db'
+            }
+          },
+          modelDefinitions: [
+            {
+              definition: {
+                name: 'coffee-model-without-ext'
+              },
+              sourceFile: path.join(appdir.PATH, 'custom-models', 'coffee-model-without-ext')
+            },
+            {
+              definition: {
+                name: 'js-model-without-ext'
+              },
+              sourceFile: path.join(appdir.PATH, 'custom-models', 'js-model-without-ext')
+            }
+          ],
+          dataSources: dataSources
+        });
+        expect(instruction.models[0].name).to.equal('coffee-model-without-ext');
+        expect(instruction.models[0].sourceFile)
+          .to.equal(path.join(appdir.PATH, 'custom-models', 'coffee-model-without-ext.coffee'));
+
+        expect(instruction.models[1].name).to.equal('js-model-without-ext');
+        expect(instruction.models[1].sourceFile)
+          .to.equal(path.join(appdir.PATH, 'custom-models', 'js-model-without-ext.js'));
+      });
+
       it('should set source file path if the file exist.', function() {
         appdir.writeFileSync('custom-models/model-with-definitions.js', '');
         var instruction = boot.compile({
@@ -121,7 +187,8 @@ describe('compiler', function() {
         });
         expect(instruction.models[0].name).to.equal('model-with-definitions');
         expect(instruction.models[0].definition).not.to.equal(undefined);
-        expect(instruction.models[0].sourceFile).not.to.equal(undefined);
+        expect(instruction.models[0].sourceFile)
+          .to.equal(path.join(appdir.PATH, 'custom-models', 'model-with-definitions.js'));
       });
 
       it('should not set source file path if the file does not exist.', function() {

--- a/test/compiler.test.js
+++ b/test/compiler.test.js
@@ -28,8 +28,34 @@ describe('compiler', function() {
         models: {
           'foo-bar-bat-baz': {
             dataSource: 'the-db'
+          },
+          'foo-bar-bat-baz-with-def': {
+            dataSource: 'the-db'
+          },
+          'foo-bar-bat-baz-with-def-no-source': {
+            dataSource: 'the-db'
           }
         },
+        modelDefinitions: [
+          {
+            definition: {
+              name: 'foo-bar-bat-baz-with-def'
+            },
+            sourceFile: path.join(SIMPLE_APP, 'common', 'models', 'foo-bar-bat-baz-with-def.js')
+          },
+          {
+            definition: { // sourceFile is a not existing file.
+              name: 'foo-bar-bat-baz-with-def-no-source'
+            },
+            sourceFile: path.join(SIMPLE_APP, 'common', 'models', 'foo-bar-bat-baz-with-def!!!.js')
+          },
+          {
+            definition: {
+              name: 'i-should-not-exist' //not in 'models'
+            },
+            sourceFile: path.join(SIMPLE_APP, 'common', 'models', 'i-should-not-exist.js')
+          }
+        ],
         dataSources: {
           'the-db': {
             connector: 'memory',
@@ -61,7 +87,7 @@ describe('compiler', function() {
     });
 
     it('has models definition', function() {
-      expect(instructions.models).to.have.length(1);
+      expect(instructions.models).to.have.length(3);
       expect(instructions.models[0]).to.eql({
         name: 'foo-bar-bat-baz',
         config: {
@@ -70,6 +96,16 @@ describe('compiler', function() {
         definition: undefined,
         sourceFile: undefined
       });
+    });
+
+    it('load model definitions from object', function() {
+      expect(instructions.models[1].name).to.equal('foo-bar-bat-baz-with-def');
+      expect(instructions.models[1].definition).not.to.equal(undefined);
+      expect(instructions.models[1].sourceFile).not.to.equal(undefined);
+
+      expect(instructions.models[2].name).to.equal('foo-bar-bat-baz-with-def-no-source');
+      expect(instructions.models[2].definition).not.to.equal(undefined);
+      expect(instructions.models[2].sourceFile).to.equal(undefined);
     });
 
     it('has datasources definition', function() {

--- a/test/fixtures/simple-app/common/models/foo-bar-bat-baz-with-def.js
+++ b/test/fixtures/simple-app/common/models/foo-bar-bat-baz-with-def.js
@@ -1,0 +1,3 @@
+module.exports = function (fooBarBatBazWithDef) {
+  fooBarBatBazWithDef.loaded = true;
+};

--- a/test/fixtures/simple-app/common/models/foo-bar-bat-baz-with-def.js
+++ b/test/fixtures/simple-app/common/models/foo-bar-bat-baz-with-def.js
@@ -1,3 +1,0 @@
-module.exports = function (fooBarBatBazWithDef) {
-  fooBarBatBazWithDef.loaded = true;
-};


### PR DESCRIPTION
Extend the options argument of boot/compile to allow the developer to supply custom model definitions (to replace the result of findModelDefinitions). Together with the existing options.models, it will allow you to specify all model-related data and still use the benefits which loopback-boot provides (most notably loading models in order defined by inheritance, i.e. base models are loaded before models that are extending them).

See @bajtos issue, #49 