### PR TITLE
Resolve relative paths in bootScripts using appRootDir

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -62,8 +62,11 @@ module.exports = function compile(options) {
   // require directories
   var bootDirs = options.bootDirs || []; // precedence
   bootDirs = bootDirs.concat(path.join(appRootDir, 'boot'));
+  resolveRelativePaths(bootDirs, appRootDir);
 
   var bootScripts = options.bootScripts || [];
+  resolveRelativePaths(bootScripts, appRootDir);
+
   bootDirs.forEach(function(dir) {
     bootScripts = bootScripts.concat(findScripts(dir));
   });
@@ -493,5 +496,14 @@ function buildComponentInstructions(rootDir, componentConfig) {
       sourceFile: sourceFile,
       config: componentConfig[name]
     };
+  });
+}
+
+function resolveRelativePaths(relativePaths, appRootDir) {
+  relativePaths.forEach(function(relativePath, k) {
+    var start = relativePath.substring(0, 2);
+    if (start === './' || start === '..') {
+      relativePaths[k] = path.resolve(appRootDir, relativePath);
+    }
   });
 }

--- a/test/compiler.test.js
+++ b/test/compiler.test.js
@@ -417,6 +417,28 @@ describe('compiler', function() {
       expect(instructions.files.boot).to.eql([initJs]);
     });
 
+    it('should resolve relative path in `bootScripts`', function() {
+      appdir.createConfigFilesSync();
+      var initJs = appdir.writeFileSync('custom-boot/init.js',
+        'module.exports = function(app) { app.fnCalled = true; };');
+      var instructions = boot.compile({
+        appRootDir: appdir.PATH,
+        bootScripts: ['./custom-boot/init.js']
+      });
+      expect(instructions.files.boot).to.eql([initJs]);
+    });
+
+    it('should resolve relative path in `bootDirs`', function() {
+      appdir.createConfigFilesSync();
+      var initJs = appdir.writeFileSync('custom-boot/init.js',
+        'module.exports = function(app) { app.fnCalled = true; };');
+      var instructions = boot.compile({
+        appRootDir: appdir.PATH,
+        bootDirs:['./custom-boot']
+      });
+      expect(instructions.files.boot).to.eql([initJs]);
+    });
+
     it('ignores models/ subdirectory', function() {
       appdir.createConfigFilesSync();
       appdir.writeFileSync('models/my-model.js', '');


### PR DESCRIPTION
In reference to - https://github.com/strongloop/loopback-boot/issues/65
1. Added function to resolve relative paths in both ```bootScripts``` and ```bootDirs``` with respect to the app root directory.
2. Added test cases to verify the change.

@bajtos, can you please review?