### PR TITLE
Resolve module paths as relative to appRootDir

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -150,7 +150,7 @@ function findScripts(dir) {
   var results = [];
   files.forEach(function(filename) {
     // ignore index.js and files prefixed with underscore
-    if ((filename === 'index.js') || (filename[0] === '_')) {
+    if (filename === 'index.js' || filename[0] === '_') {
       return;
     }
 
@@ -165,11 +165,7 @@ function findScripts(dir) {
       else
         debug('Skipping file %s - unknown extension', filepath);
     } else {
-      try {
-        path.join(require.resolve(filepath));
-      } catch (err) {
-        debug('Skipping directory %s - %s', filepath, err.code || err);
-      }
+      debug('Skipping directory %s', filepath);
     }
   });
 
@@ -270,7 +266,7 @@ function findModelDefinitions(rootDir, sources) {
   var registry = {};
 
   sources.forEach(function(src) {
-    var srcDir = resolveSourceDir(rootDir, src);
+    var srcDir = resolveAppPath(rootDir, src);
     if (!srcDir) {
       debug('Skipping unknown module source dir %j', src);
       return;
@@ -298,14 +294,15 @@ function findModelDefinitions(rootDir, sources) {
   return registry;
 }
 
-function resolveSourceDir(rootDir, sourceDir) {
-  var srcDir = path.resolve(rootDir, sourceDir);
-  if (fs.existsSync(srcDir))
-    return srcDir;
+function resolveAppPath(rootDir, relativePath) {
+  var fullPath = path.resolve(rootDir, relativePath);
+  if (fs.existsSync(fullPath))
+    return fullPath;
 
-  // Handle module-relative path, e.g. `loopback/common/models`
-  var start = sourceDir.substring(0, 2);
+  var start = relativePath.substring(0, 2);
   if (start !== './' && start !== '..') {
+    // Handle module-relative path, e.g. `loopback/common/models`
+
     // Module.globalPaths is a list of globally configured paths like
     //   [ env.NODE_PATH values, $HOME/.node_modules, etc. ]
     // Module._nodeModulePaths(rootDir) returns a list of paths like
@@ -313,16 +310,24 @@ function resolveSourceDir(rootDir, sourceDir) {
     var modulePaths = Module.globalPaths
       .concat(Module._nodeModulePaths(rootDir));
 
-    srcDir = modulePaths
+    fullPath = modulePaths
       .map(function(candidateDir) {
-        return path.join(candidateDir, sourceDir);
+        return path.join(candidateDir, relativePath);
       })
       .filter(function(candidate) {
         return fs.existsSync(candidate);
       })
       [0];
-    if (srcDir)
-      return srcDir;
+    if (fullPath)
+      return fullPath;
+  } else {
+    // Handle relative path, e.g. `./common/models`
+    try {
+      fullPath = require.resolve(fullPath);
+      return fullPath;
+    } catch (err) {
+      debug ('Skipping %s - %s', fullPath, err);
+    }
   }
 
   return undefined;
@@ -503,9 +508,11 @@ function buildComponentInstructions(rootDir, componentConfig) {
 
 function resolveRelativePaths(relativePaths, appRootDir) {
   relativePaths.forEach(function(relativePath, k) {
-    var start = relativePath.substring(0, 2);
-    if (start === './' || start === '..') {
-      relativePaths[k] = path.resolve(appRootDir, relativePath);
+    var resolvedPath = resolveAppPath(appRootDir, relativePath);
+    if (resolvedPath !== undefined) {
+      relativePaths[k] = resolvedPath;
+    } else {
+      debug ('skipping boot script %s - unknown file', relativePath);
     }
   });
 }

--- a/test/compiler.test.js
+++ b/test/compiler.test.js
@@ -439,6 +439,69 @@ describe('compiler', function() {
       expect(instructions.files.boot).to.eql([initJs]);
     });
 
+    it('should resolve non-relative path in `bootScripts`', function() {
+      appdir.createConfigFilesSync();
+      var initJs = appdir.writeFileSync('custom-boot/init.js', '');
+      var instructions = boot.compile({
+        appRootDir: appdir.PATH,
+        bootScripts: ['custom-boot/init.js']
+      });
+      expect(instructions.files.boot).to.eql([initJs]);
+    });
+
+    it('should resolve non-relative path in `bootDirs`', function() {
+      appdir.createConfigFilesSync();
+      var initJs = appdir.writeFileSync('custom-boot/init.js', '');
+      var instructions = boot.compile({
+        appRootDir: appdir.PATH,
+        bootDirs:['custom-boot']
+      });
+      expect(instructions.files.boot).to.eql([initJs]);
+    });
+
+    it('resolves missing extensions in `bootScripts`', function() {
+      appdir.createConfigFilesSync();
+      var initJs = appdir.writeFileSync('custom-boot/init.js', '');
+      var instructions = boot.compile({
+        appRootDir: appdir.PATH,
+        bootScripts:['./custom-boot/init']
+      });
+      expect(instructions.files.boot).to.eql([initJs]);
+    });
+
+    it('ignores index.js in `bootDirs`', function() {
+      appdir.createConfigFilesSync();
+      appdir.writeFileSync('custom-boot/index.js', '');
+      var instructions = boot.compile({
+        appRootDir: appdir.PATH,
+        bootDirs:['./custom-boot']
+      });
+      expect(instructions.files.boot).to.have.length(0);
+    });
+
+    it('resolves module relative path for `bootScripts`', function() {
+      appdir.createConfigFilesSync();
+      var initJs = appdir.writeFileSync('node_modules/custom-boot/init.js', '');
+      var instructions = boot.compile({
+        appRootDir: appdir.PATH,
+        bootScripts: ['custom-boot/init.js']
+      });
+      expect(instructions.files.boot).to.eql([initJs]);
+    });
+
+    it('explores `bootScripts` in app relative path', function() {
+      appdir.createConfigFilesSync();
+      var appJs = appdir.writeFileSync('./custom-boot/init.js', '');
+
+      appdir.writeFileSync('node_modules/custom-boot/init.js', '');
+
+      var instructions = boot.compile({
+        appRootDir: appdir.PATH,
+        bootScripts: ['custom-boot/init.js']
+      });
+      expect(instructions.files.boot).to.eql([appJs]);
+    });
+
     it('ignores models/ subdirectory', function() {
       appdir.createConfigFilesSync();
       appdir.writeFileSync('models/my-model.js', '');


### PR DESCRIPTION
In context of - https://github.com/strongloop/loopback-boot/issues/73, made following changes...
 1. Added test case to verify that a call to <br/>
```app.boot(app, { appRootDir: __dirname, bootScripts: ["./custom-boot/script" ] })```
<br/> resolves boot script as ``` __dirname+"/custom-boot/script.js"```

@bajtos, please review.