### PR TITLE
Resolve missing file extension for module relative paths

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -312,7 +312,13 @@ function resolveAppPath(rootDir, relativePath) {
 
     fullPath = modulePaths
       .map(function(candidateDir) {
-        return path.join(candidateDir, relativePath);
+        try {
+          var filePath = path.join(candidateDir, relativePath);
+          filePath = require.resolve(filePath);
+          return filePath;
+        } catch (err) {
+          return filePath;
+        }
       })
       .filter(function(candidate) {
         return fs.existsSync(candidate);

--- a/test/compiler.test.js
+++ b/test/compiler.test.js
@@ -469,6 +469,18 @@ describe('compiler', function() {
       expect(instructions.files.boot).to.eql([initJs]);
     });
 
+    it('resolves missing extensions in `bootScripts` in module relative path',
+      function() {
+      appdir.createConfigFilesSync();
+      var initJs = appdir.writeFileSync('node_modules/custom-boot/init.js', '');
+
+      var instructions = boot.compile({
+        appRootDir: appdir.PATH,
+        bootScripts: ['custom-boot/init']
+      });
+      expect(instructions.files.boot).to.eql([initJs]);
+    });
+
     it('ignores index.js in `bootDirs`', function() {
       appdir.createConfigFilesSync();
       appdir.writeFileSync('custom-boot/index.js', '');


### PR DESCRIPTION
Referring to https://github.com/strongloop/loopback-boot/pull/107#issuecomment-81482441, added a fix so as to resolve missing file extensions on module relative paths.

@bajtos - Can you review?