### PR TITLE
Support per-application registry of models

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -168,23 +168,24 @@ function setupModels(app, instructions) {
 }
 
 function defineModels(app, instructions) {
+  var registry = app.registry || app.loopback;
   instructions.models.forEach(function(data) {
     var name = data.name;
     var model;
 
     if (!data.definition) {
-      model = app.loopback.getModel(name);
+      model = registry.getModel(name);
       if (!model) {
         throw new Error('Cannot configure unknown model ' + name);
       }
       debug('Configuring existing model %s', name);
     } else if (isBuiltinLoopBackModel(app, data)) {
-      model = app.loopback[name];
-      assert(model, 'app.loopback[model] should have been defined');
+      model = registry.getModel(name);
+      assert(model, 'Built-in model ' + name + ' should have been defined');
       debug('Configuring built-in LoopBack model %s', name);
     } else {
       debug('Creating new model %s %j', name, data.definition);
-      model = app.loopback.createModel(data.definition);
+      model = registry.createModel(data.definition);
       if (data.sourceFile) {
         debug('Loading customization script %s', data.sourceFile);
         var code = require(data.sourceFile);


### PR DESCRIPTION
A follow-up for https://github.com/strongloop/loopback/pull/1212 implementing support for local per-app model registries.

/to @ritch 
/cc @kraman 