### PR TITLE
Resolve module paths as relative to appRootDir - for middleware

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -266,7 +266,7 @@ function findModelDefinitions(rootDir, sources) {
   var registry = {};
 
   sources.forEach(function(src) {
-    var srcDir = resolveAppPath(rootDir, src);
+    var srcDir = tryResolveAppPath(rootDir, src);
     if (!srcDir) {
       debug('Skipping unknown module source dir %j', src);
       return;
@@ -295,6 +295,16 @@ function findModelDefinitions(rootDir, sources) {
 }
 
 function resolveAppPath(rootDir, relativePath) {
+  var resolvedPath = tryResolveAppPath(rootDir, relativePath);
+  if (resolvedPath === undefined) {
+    var err = new Error('Cannot resolve path "' + relativePath + '"');
+    err.code = 'PATH_NOT_FOUND';
+    throw err;
+  }
+  return resolvedPath;
+}
+
+function tryResolveAppPath(rootDir, relativePath) {
   var fullPath = path.resolve(rootDir, relativePath);
   if (fs.existsSync(fullPath))
     return fullPath;
@@ -429,6 +439,7 @@ function resolveMiddlewarePath(rootDir, middleware) {
   var segments = middleware.split('#');
   var pathName = segments[0];
   var fragment = segments[1];
+  var middlewarePath = pathName;
 
   if (fragment) {
     resolved.fragment = fragment;
@@ -440,7 +451,7 @@ function resolveMiddlewarePath(rootDir, middleware) {
   }
 
   if (!fragment) {
-    resolved.sourceFile = require.resolve(pathName);
+    resolved.sourceFile = resolveAppPath(rootDir, middlewarePath);
     return resolved;
   }
 
@@ -450,7 +461,7 @@ function resolveMiddlewarePath(rootDir, middleware) {
   // function
   var m = require(pathName);
   if (typeof m[fragment] === 'function') {
-    resolved.sourceFile = require.resolve(pathName);
+    resolved.sourceFile = resolveAppPath(rootDir, middlewarePath);
     return resolved;
   }
 
@@ -468,7 +479,7 @@ function resolveMiddlewarePath(rootDir, middleware) {
 
   for (var ix in candidates) {
     try {
-      resolved.sourceFile = require.resolve(candidates[ix]);
+      resolved.sourceFile = resolveAppPath(rootDir, candidates[ix]);
       delete resolved.fragment;
       return resolved;
     }
@@ -514,7 +525,7 @@ function buildComponentInstructions(rootDir, componentConfig) {
 
 function resolveRelativePaths(relativePaths, appRootDir) {
   relativePaths.forEach(function(relativePath, k) {
-    var resolvedPath = resolveAppPath(appRootDir, relativePath);
+    var resolvedPath = tryResolveAppPath(appRootDir, relativePath);
     if (resolvedPath !== undefined) {
       relativePaths[k] = resolvedPath;
     } else {


### PR DESCRIPTION
In continuation with #73, 
 1. Made modifications to middleware, so as to resolve the module paths relative to appRootDir.
 2. Added test cases to verify middleware changes.

@bajtos - Can you please review?

