### PR TITLE
add console.error message to a bad require in a boot script

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -231,13 +231,18 @@ function runScripts(app, list, callback) {
   var functions = [];
   list.forEach(function(filepath) {
     debug('Requiring script %s', filepath);
-    var exports = require(filepath);
-    if (typeof exports === 'function') {
-      debug('Exported function detected %s', filepath);
-      functions.push({
-        path: filepath,
-        func: exports
-      });
+    try {
+      var exports = require(filepath);
+      if (typeof exports === 'function') {
+        debug('Exported function detected %s', filepath);
+        functions.push({
+          path: filepath,
+          func: exports
+        });
+      }
+    } catch (err) {
+      console.error('Failed loading boot script: %s\n%s', filepath, err.stack);
+      throw err;
     }
   });
 


### PR DESCRIPTION
I just hit this last night and thought it would be nice to have an error print out.  

I also found strongloop/loopback#1170 which I think this would fix but I don't agree that I should crash the server on a failing boot script, the error log should be enough to realize what happened.

The change produces the following error message in the tests:
`Failed loading boot script badScript.js`
`Cannot find module 'doesnt-exist’`

Let me know if you'd like to see any other changes.