### PR TITLE
upgrade lodash and drop underscore.string

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -6,7 +6,9 @@ var toposort = require('toposort');
 var ConfigLoader = require('./config-loader');
 var debug = require('debug')('loopback:boot:compiler');
 var Module = require('module');
-var _ = require('lodash');
+var uniq = require('lodash/array/uniq');
+var capitalize = require('lodash/string/capitalize');
+var camelCase = require('lodash/string/camelCase');
 
 var FILE_EXTENSION_JSON = '.json';
 
@@ -75,7 +77,7 @@ module.exports = function compile(options) {
 
   // de-dedup boot scripts -ERS
   // https://github.com/strongloop/loopback-boot/issues/64
-  bootScripts = _.uniq(bootScripts);
+  bootScripts = uniq(bootScripts);
 
   var modelsMeta = modelsConfig._meta || {};
   delete modelsConfig._meta;
@@ -383,7 +385,7 @@ function tryResolveAppPath(rootDir, relativePath, resolveOptions) {
 function loadModelDefinition(rootDir, jsonFile, allFiles) {
   var definition = require(jsonFile);
   var basename = path.basename(jsonFile, path.extname(jsonFile));
-  definition.name = definition.name || _.capitalize(_.camelCase(basename));
+  definition.name = definition.name || capitalize(camelCase(basename));
 
   // find a matching file with a supported extension like `.js` or `.coffee`
   var sourceFile = fixFileExtension(jsonFile, allFiles, true);

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -7,7 +7,6 @@ var ConfigLoader = require('./config-loader');
 var debug = require('debug')('loopback:boot:compiler');
 var Module = require('module');
 var _ = require('lodash');
-var _s = require('underscore.string');
 
 var FILE_EXTENSION_JSON = '.json';
 
@@ -384,7 +383,7 @@ function tryResolveAppPath(rootDir, relativePath, resolveOptions) {
 function loadModelDefinition(rootDir, jsonFile, allFiles) {
   var definition = require(jsonFile);
   var basename = path.basename(jsonFile, path.extname(jsonFile));
-  definition.name = definition.name || _s.capitalize(_s.camelize(basename));
+  definition.name = definition.name || _.capitalize(_.camelCase(basename));
 
   // find a matching file with a supported extension like `.js` or `.coffee`
   var sourceFile = fixFileExtension(jsonFile, allFiles, true);

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -116,7 +116,9 @@ function setPort(app, instructions) {
     process.env.npm_package_config_port,
     app.get('port'),
     3000
-  ], _.isFinite);
+  ], function(v) {
+    return _.isFinite(parseInt(v, 10));
+  });
 
   if (port !== undefined) {
     var portType = typeof port;

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var _ = require('lodash');
+var find = require('lodash/collection/find');
 var semver = require('semver');
 var debug = require('debug')('loopback:boot:executor');
 var async = require('async');
@@ -107,7 +107,7 @@ function setHost(app, instructions) {
 
 function setPort(app, instructions) {
   // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
-  var port = _.find([
+  var port = find([
     process.env.npm_config_port,
     process.env.OPENSHIFT_SLS_PORT,
     process.env.OPENSHIFT_NODEJS_PORT,
@@ -116,9 +116,7 @@ function setPort(app, instructions) {
     process.env.npm_package_config_port,
     app.get('port'),
     3000
-  ], function(v) {
-    return _.isFinite(parseInt(v, 10));
-  });
+  ], function isNumberLike(v) { return Number.isFinite(parseInt(v, 10)); });
 
   if (port !== undefined) {
     var portType = typeof port;

--- a/package.json
+++ b/package.json
@@ -26,10 +26,9 @@
     "async": "~0.9.0",
     "commondir": "0.0.1",
     "debug": "^2.0.0",
-    "lodash": "^2.4.1",
+    "lodash": "^3.6.0",
     "semver": "^4.1.0",
-    "toposort": "^0.2.10",
-    "underscore.string": "^3.0.3"
+    "toposort": "^0.2.10"
   },
   "devDependencies": {
     "browserify": "^4.1.8",


### PR DESCRIPTION
If we update to the latest stable lodash we can use the sting functions included and drop the usage of underscore.string.
`isFinite` changed from the older version of lodash to no longer coerce strings into numbers so we need to use `parseInt` before checking. `parseInt` on an `undefined` returns `NaN` which `isFinite` does not identify as a number.
Existing tests run checks for `flying-car` definitions to be named `FlyingCar` so there doesn’t seem to be a need to add more checks.