### PR TITLE
Enable .js extension for master config files

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -31,7 +31,8 @@ ConfigLoader.loadDataSources = function(rootDir, env) {
  */
 ConfigLoader.loadModels = function(rootDir, env) {
   /*jshint unused:false */
-  return tryReadJsonConfig(rootDir, 'model-config') || {};
+  return tryReadJsonConfig(rootDir, 'model-config') ||
+         tryReadJsConfig(rootDir, 'model-config') || {};
 };
 
 /**
@@ -78,7 +79,7 @@ function loadNamed(rootDir, env, name, mergeFn) {
  * @returns {Array.<String>} Array of absolute file paths.
  */
 function findConfigFiles(appRootDir, env, name) {
-  var master = ifExists(name + '.json');
+  var master = ifExists(name + '.json') || ifExists(name + '.js');
   if (!master) return [];
 
   var candidates = [
@@ -243,17 +244,37 @@ function hasCompatibleType(origValue, newValue) {
 }
 
 /**
+ * Try to read a config file with the specified file name
+ * @param {string} cwd Dirname of the file
+ * @param {string} fileName Name of the file with extension
+ * @returns {Object|undefined} Content of the file, undefined if not found.
+ */
+function tryReadConfig(cwd, fileName) {
+  try {
+    return require(path.join(cwd, fileName));
+  } catch (e) {
+    if (e.code !== 'MODULE_NOT_FOUND') {
+      throw e;
+    }
+  }
+}
+
+/**
+ * Try to read a config file with .js extension
+ * @param {string} cwd Dirname of the file
+ * @param {string} fileName Name of the file without extension
+ * @returns {Object|undefined} Content of the file, undefined if not found.
+ */
+function tryReadJsConfig(cwd, fileName) {
+  return tryReadConfig(cwd, fileName + '.js');
+}
+
+/**
  * Try to read a config file with .json extension
  * @param {string} cwd Dirname of the file
  * @param {string} fileName Name of the file without extension
  * @returns {Object|undefined} Content of the file, undefined if not found.
  */
 function tryReadJsonConfig(cwd, fileName) {
-  try {
-    return require(path.join(cwd, fileName + '.json'));
-  } catch (e) {
-    if (e.code !== 'MODULE_NOT_FOUND') {
-      throw e;
-    }
-  }
+  return tryReadConfig(cwd, fileName + '.json');
 }


### PR DESCRIPTION
Some people (including myself) have run into the problem, that loopback-boot doesn't work properly with .js config files. After this modification, loopback-boot will try to load a .js file when a .json master config is not available. This includes model-config, which probably doesn't have much need for a .js file, but a possibility to have it is not a bad thing imo. The behaviour with .local and .{env} files is not changed (that is .js files are preferred to .json).