### PR TITLE
executor: fix port lookup

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -115,9 +115,7 @@ function setPort(app, instructions) {
     process.env.npm_package_config_port,
     app.get('port'),
     3000
-  ], function isNumberLike(v) {
-    return Number.isFinite(parseInt(v, 10));
-  });
+  ], isFinite);
 
   if (port !== undefined) {
     var portType = typeof port;


### PR DESCRIPTION
Use the global `isFinite` function to find the first valid port number. This is the same behaviour as `_.isFinite` in lodash@2.x.

As a result, only values that are a valid number are accepted, e.g. "0" is accepted but "0xy" is not.

This patch is fixing a regression introduced in 044a4df07a8c076ec0c72e98261fdb44631f7acd.

/to @raymondfeng please review