### PR TITLE
Upgrade to lodash 3.x

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var cloneDeep = require('lodash.clonedeep');
+var cloneDeep = require('lodash/lang/cloneDeep');
 var fs = require('fs');
 var path = require('path');
 var ConfigLoader = require('./config-loader');

--- a/package.json
+++ b/package.json
@@ -30,11 +30,12 @@
     "underscore": "^1.6.0"
   },
   "devDependencies": {
+    "browserify": "^4.1.8",
+    "fs-extra": "^0.9.1",
+    "jshint": "^2.7.0",
     "loopback": "^1.5.0",
     "mocha": "^1.19.0",
     "must": "^0.11.0",
-    "supertest": "^0.13.0",
-    "fs-extra": "^0.9.1",
-    "browserify": "^4.1.8"
+    "supertest": "^0.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "commondir": "0.0.1",
     "debug": "^0.8.1",
-    "lodash.clonedeep": "^2.4.1",
+    "lodash": "^3.7.0",
     "semver": "^2.3.0",
     "underscore": "^1.6.0"
   },

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -8,6 +8,7 @@ var vm = require('vm');
 
 describe('browser support', function() {
   this.timeout(60000); // 60s to give browserify enough time to finish
+  beforeEach(sandbox.reset);
 
   it('has API for bundling and executing boot instructions', function(done) {
     var appDir = path.resolve(__dirname, './fixtures/browser-app');


### PR DESCRIPTION
Replace single-function module with full lodash, which can be shared with other packages if installed in a parent module.

See strongloop/strongloop#213 for context. This is an interim solution so that loopback-workspace can benefit from this change without having to upgrade to loopback-boot 2.x.