### PR TITLE
Port can't be number checked to support iisnode

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -115,7 +115,9 @@ function setPort(app, instructions) {
     process.env.npm_package_config_port,
     app.get('port'),
     3000
-  ], isFinite);
+  ], function(p) {
+    return p != null;
+  });
 
   if (port !== undefined) {
     var portType = typeof port;

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -406,10 +406,10 @@ describe('executor', function() {
       assert.equal(app.get('port'), 3000);
     });
 
-    it('should ignore non-numeric port values in ENV', function() {
-      process.env.PORT = '123invalid';
+    it('should respect named pipes port values in ENV', function() {
+      process.env.PORT = '\.\pipe\test';
       boot.execute(app, someInstructions({ config: { port: 3000 } }));
-      assert.equal(app.get('port'), 3000);
+      assert.equal(app.get('port'), '\.\pipe\test');
     });
   });
 


### PR DESCRIPTION
Using a parseInt() or number isNumber function won't work if we want to support iisnode which uses named pipes for ports (ex. \\.\pipe\mypipe)