### PR TITLE
support 'mixinsources' option

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -85,8 +85,9 @@ module.exports = function compile(options) {
     modelsRootDir, modelsConfig, modelSources);
 
   var mixinDirs = options.mixinDirs || [];
+  var mixinSources = options.mixinSources || modelsMeta.mixins || ['./mixins'];
   var mixinInstructions = buildAllMixinInstructions(
-    appRootDir, mixinDirs, options);
+    appRootDir, mixinDirs, mixinSources, options, modelInstructions);
 
   // When executor passes the instruction to loopback methods,
   // loopback modifies the data. Since we are loading the data using `require`,
@@ -606,12 +607,48 @@ function resolveAppScriptPath(rootDir, relativePath, resolveOptions) {
   return (fixedFile === undefined ? resolvedPath : fixedFile);
 }
 
-function buildAllMixinInstructions(appRootDir, mixinDirs, options) {
+function buildAllMixinInstructions(appRootDir, mixinDirs, mixinSources, options,
+  modelInstructions) {
   var extensions = _.without(_.keys(require.extensions),
     _.keys(getExcludedExtensions()));
-  var files = options.mixins || [];
 
-  mixinDirs.forEach(function(dir) {
+  // load mixins from `options.mixins`
+  var sourceFiles = options.mixins || [];
+  var instructionsFromMixins = loadMixins(sourceFiles, options);
+
+  // load mixins from `options.mixinDirs`
+  sourceFiles = findMixinDefinitions(appRootDir, mixinDirs, extensions);
+  if (sourceFiles === undefined) return;
+  var instructionsFromMixinDirs = loadMixins(sourceFiles, options);
+
+  /* If `mixinDirs` and `mixinSources` have any directories in common,
+   * then remove the common directories from `mixinSources` */
+  mixinSources = _.difference(mixinSources, mixinDirs);
+
+  // load mixins from `options.mixinSources`
+  sourceFiles = findMixinDefinitions(appRootDir, mixinSources, extensions);
+  if (sourceFiles === undefined) return;
+  var instructionsFromMixinSources = loadMixins(sourceFiles, options);
+
+  // Fetch unique list of mixin names, used in models
+  var modelMixins = fetchMixinNamesUsedInModelInstructions(modelInstructions);
+  modelMixins = _.unique(modelMixins);
+
+  // Filter-in only mixins, that are used in models
+  instructionsFromMixinSources = filterMixinInstructionsUsingWhitelist(
+    instructionsFromMixinSources, modelMixins);
+
+  var mixins = _.assign(
+    instructionsFromMixins,
+    instructionsFromMixinDirs,
+    instructionsFromMixinSources);
+
+  return _.values(mixins);
+}
+
+function findMixinDefinitions(appRootDir, sourceDirs, extensions) {
+  var files = [];
+  sourceDirs.forEach(function(dir) {
     dir = tryResolveAppPath(appRootDir, dir);
     if (!dir) {
       debug('Skipping unknown module source dir %j', dir);
@@ -619,8 +656,12 @@ function buildAllMixinInstructions(appRootDir, mixinDirs, options) {
     }
     files = files.concat(findScripts(dir, extensions));
   });
+  return files;
+}
 
-  var mixins = files.map(function(filepath) {
+function loadMixins(sourceFiles, options) {
+  var mixinInstructions = {};
+  sourceFiles.forEach(function(filepath) {
     var dir = path.dirname(filepath);
     var ext = path.extname(filepath);
     var name = path.basename(filepath, ext);
@@ -634,10 +675,31 @@ function buildAllMixinInstructions(appRootDir, mixinDirs, options) {
       _.extend(meta, require(metafile));
     }
     meta.sourceFile = filepath;
-    return meta;
+    mixinInstructions[meta.name] = meta;
   });
 
-  return mixins;
+  return mixinInstructions;
+}
+
+function fetchMixinNamesUsedInModelInstructions(modelInstructions) {
+  return _.flatten(modelInstructions
+  .map(function(model) {
+    return model.definition && model.definition.mixins ?
+      Object.keys(model.definition.mixins) : [];
+  }));
+}
+
+function filterMixinInstructionsUsingWhitelist(instructions, includeMixins) {
+  var instructionKeys = Object.keys(instructions);
+  includeMixins = _.intersection(instructionKeys, includeMixins);
+
+  var filteredInstructions = {};
+  instructionKeys.forEach(function(mixinName) {
+    if (includeMixins.indexOf(mixinName) !== -1) {
+      filteredInstructions[mixinName] = instructions[mixinName];
+    }
+  });
+  return filteredInstructions;
 }
 
 function normalizeMixinName(str, options) {

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -64,8 +64,7 @@ describe('browser support', function() {
   it('loads mixins', function(done) {
     var appDir = path.resolve(__dirname, './fixtures/browser-app');
     var options = {
-      appRootDir: appDir,
-      mixinDirs: ['./mixins']
+      appRootDir: appDir
     };
 
     browserifyTestApp(options, function(err, bundlePath) {

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -293,28 +293,39 @@ describe('executor', function() {
     });
 
     describe ('for mixins', function() {
-      it('defines mixins from instructions', function() {
-        appdir.writeFileSync('mixins/example.js',
+      var options;
+      beforeEach(function() {
+        appdir.writeFileSync('custom-mixins/example.js',
           'module.exports = ' +
           'function(Model, options) {}');
 
-        appdir.writeFileSync('mixins/time-stamps.js',
+        appdir.writeFileSync('custom-mixins/time-stamps.js',
           'module.exports = ' +
           'function(Model, options) {}');
 
-        appdir.writeConfigFileSync('mixins/time-stamps.json', {
+        appdir.writeConfigFileSync('custom-mixins/time-stamps.json', {
           name: 'Timestamping'
         });
 
-        var options = {
-          appRootDir: appdir.PATH,
-          mixinDirs: ['./mixins']
+        options = {
+          appRootDir: appdir.PATH
         };
+      });
 
+      it('defines mixins from instructions - using `mixinDirs`', function() {
+        options.mixinDirs = ['./custom-mixins'];
         boot(app, options);
 
         var modelBuilder = app.registry.modelBuilder;
+        var registry = modelBuilder.mixins.mixins;
+        expect(Object.keys(registry)).to.eql(['Example', 'Timestamping']);
+      });
 
+      it('defines mixins from instructions - using `mixinSources`', function() {
+        options.mixinSources = ['./custom-mixins'];
+        boot(app, options);
+
+        var modelBuilder = app.registry.modelBuilder;
         var registry = modelBuilder.mixins.mixins;
         expect(Object.keys(registry)).to.eql(['Example', 'Timestamping']);
       });


### PR DESCRIPTION
In continuation with - https://github.com/strongloop/loopback-boot/issues/79, added support for ```mixinSources``` option.

The implementation -
- By default looks for mixinsources in ```mixins``` directory
- Loads only mixins used through models

Connect to #79

@bajtos - Can you review?