### PR TITLE
use a new variable for better debug output

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -689,12 +689,12 @@ function buildAllMixinInstructions(appRootDir, mixinDirs, mixinSources, options,
 function findMixinDefinitions(appRootDir, sourceDirs, extensions) {
   var files = [];
   sourceDirs.forEach(function(dir) {
-    dir = tryResolveAppPath(appRootDir, dir);
-    if (!dir) {
+    var path = tryResolveAppPath(appRootDir, dir);
+    if (!path) {
       debug('Skipping unknown module source dir %j', dir);
       return;
     }
-    files = files.concat(findScripts(dir, extensions));
+    files = files.concat(findScripts(path, extensions));
   });
   return files;
 }


### PR DESCRIPTION
Because `tryResolveAppPath` returns `undefined` when it can’t resolve a
path the debug output for directories that cannot be resolved is fairly useless.

You get output like this:
`loopback:boot:compiler Skipping unknown module source dir undefined +0ms`

When you want output like this:
`loopback:boot:compiler Skipping unknown module source dir "./models" +0ms`