### PR TITLE
Excl. mod. main path from middleware instructions

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -408,21 +408,29 @@ function tryResolveAppPath(rootDir, relativePath, resolveOptions) {
 
   fullPath = modulePaths
     .map(function(candidateDir) {
+      var absPath = path.join(candidateDir, relativePath);
       try {
-        var filePath = path.join(candidateDir, relativePath);
-        filePath = require.resolve(filePath);
+        // NOTE(bajtos) We need to create a proper String object here,
+        // otherwise we can't attach additional properties to it
+        /*jshint -W053 */
+        var filePath = new String(require.resolve(absPath));
+        filePath.unresolvedPath = absPath;
         return filePath;
       } catch (err) {
-        return filePath;
+        return absPath;
       }
     })
     .filter(function(candidate) {
-      return fs.existsSync(candidate);
+      return fs.existsSync(candidate.toString());
     })
     [0];
 
-  if (fullPath)
-    return fullPath;
+  if (fullPath) {
+    if (fullPath.unresolvedPath && resolveOptions.fullResolve === false)
+      return fullPath.unresolvedPath;
+    // Convert String object back to plain string primitive
+    return fullPath.toString();
+  }
 
   debug ('Skipping %s - module not found', fullPath);
   return undefined;
@@ -517,18 +525,28 @@ function resolveMiddlewarePath(rootDir, middleware) {
     pathName = path.resolve(rootDir, pathName);
   }
 
+  var resolveOpts = _.extend(opts, {
+    // Workaround for strong-agent to allow probes to detect that
+    // strong-express-middleware was loaded: exclude the path to the
+    // module main file from the source file path.
+    // For example, return
+    //   node_modules/strong-express-metrics
+    // instead of
+    //   node_modules/strong-express-metrics/index.js
+    fullResolve: false
+  });
+  var sourceFile = resolveAppScriptPath(rootDir, middlewarePath, resolveOpts);
+
   if (!fragment) {
-    resolved.sourceFile = resolveAppScriptPath(rootDir, middlewarePath, opts);
+    resolved.sourceFile = sourceFile;
     return resolved;
   }
-
-  var err;
 
   // Try to require the module and check if <module>.<fragment> is a valid
   // function
   var m = require(pathName);
   if (typeof m[fragment] === 'function') {
-    resolved.sourceFile = resolveAppScriptPath(rootDir, middlewarePath, opts);
+    resolved.sourceFile = sourceFile;
     return resolved;
   }
 
@@ -544,6 +562,7 @@ function resolveMiddlewarePath(rootDir, middleware) {
     // pathName + '/' + fragment
   ];
 
+  var err;
   for (var ix in candidates) {
     try {
       resolved.sourceFile = resolveAppScriptPath(rootDir, candidates[ix], opts);

--- a/test/compiler.test.js
+++ b/test/compiler.test.js
@@ -1759,7 +1759,7 @@ describe('compiler', function() {
 
         expect(instructions.middleware.middleware[0]).have.property(
           'sourceFile',
-          require.resolve('loopback'));
+          pathWithoutIndex(require.resolve('loopback')));
         expect(instructions.middleware.middleware[0]).have.property(
           'fragment',
           'errorHandler');
@@ -1781,7 +1781,7 @@ describe('compiler', function() {
 
       expect(instructions.middleware.middleware[0]).have.property(
         'sourceFile',
-        appdir.resolve(HANDLER_FILE));
+        pathWithoutIndex(appdir.resolve(HANDLER_FILE)));
     });
 
     it('prefers appRootDir over node_modules for middleware', function() {
@@ -1846,7 +1846,7 @@ describe('compiler', function() {
 
       expect(instructions.middleware.middleware).to.have.length(1);
       expect(instructions.middleware.middleware[0]).have.property(
-        'sourceFile', file);
+        'sourceFile', pathWithoutIndex(file));
     });
 
     it('prefers coffeescript over json for relative middleware path',
@@ -2076,4 +2076,8 @@ function pathWithoutExtension(value) {
   return path.join(
     path.dirname(value),
     path.basename(value, path.extname(value)));
+}
+
+function pathWithoutIndex(filePath) {
+  return filePath.replace(/[\\\/]index\.[^.]+$/, '');
 }


### PR DESCRIPTION
When loading middleware configured in "middleware.json", loopback-boot
used to require() the full path to middleware's module main file,
for example "node_modules/strong-express-metrics/index.js".

This is breaking strong-agent probes, as it's difficult to detect
when the intercepted module (e.g. "strong-express-metrics") was loaded.

This commit modifies the compiler to omit the tail (the path to the
module main source file) when requiring middleware.

Connect to strongloop-internal/scrum-loopback#279
See also https://github.com/strongloop/strongops/issues/278 which is fixing strong-agent.

/to @raymondfeng @sam-github please review