### PR TITLE
Enable model-config.json _meta.mixinDirs

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -84,7 +84,7 @@ module.exports = function compile(options) {
   var modelInstructions = buildAllModelInstructions(
     modelsRootDir, modelsConfig, modelSources, options.modelDefinitions);
 
-  var mixinDirs = options.mixinDirs || [];
+  var mixinDirs = options.mixinDirs || modelsMeta.mixinDirs || [];
   var mixinSources = options.mixinSources || modelsMeta.mixins || ['./mixins'];
   var mixinInstructions = buildAllMixinInstructions(
     appRootDir, mixinDirs, mixinSources, options, modelInstructions);


### PR DESCRIPTION
Hi @bajtos - it's been I while since I've booted from a base loopback install (I usually started my own boot and passed in the options there). Today I've come to realize that there is currently no way to specify `mixinDirs` from `model-config.json`. 

I'm not that happy with `_meta.mixins` vs. `_meta.mixinDirs`, but it looks like the only option right now. Ideally, I would like to just have it point to `common/mixins` by default, but that's probably a no-go, because such entries are not in loopback-boot, but in said `model-config.json`.

What are your thoughts?