### PR TITLE
Enhance middleware config merge

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -177,7 +177,30 @@ function mergePhaseConfig(target, config, phase) {
   var err;
   for (var middleware in config) {
     if (middleware in target) {
-      err = mergeObjects(target[middleware], config[middleware]);
+      var targetMiddleware = target[middleware];
+      var configMiddleware = config[middleware];
+      if (Array.isArray(targetMiddleware) && Array.isArray(configMiddleware)) {
+        // Both are arrays, combine them
+        target[middleware] = targetMiddleware.concat(configMiddleware);
+      } else if (Array.isArray(targetMiddleware)) {
+        if (typeof configMiddleware === 'object' &&
+          Object.keys(configMiddleware).length) {
+          // Config side is an non-empty object
+          targetMiddleware.push(configMiddleware);
+        }
+      } else if (Array.isArray(configMiddleware)) {
+        if (typeof targetMiddleware === 'object' &&
+          Object.keys(targetMiddleware).length) {
+          // Target side is an non-empty object
+          targetMiddleware = target[middleware] =
+            [targetMiddleware].concat(configMiddleware);
+        } else {
+          // Target side is empty
+          target[middleware] = configMiddleware;
+        }
+      } else {
+        err = mergeObjects(targetMiddleware, configMiddleware);
+      }
     } else {
       err = 'The middleware "' + middleware + '" in phase "' + phase + '"' +
         'is not defined in the main config.';

--- a/test/compiler.test.js
+++ b/test/compiler.test.js
@@ -1719,6 +1719,137 @@ describe('compiler', function() {
         .to.have.property('enabled', false);
     });
 
+    function verifyMiddlewareConfig() {
+      var instructions = boot.compile(appdir.PATH);
+
+      expect(instructions.middleware.middleware)
+        .to.eql([
+          {
+            sourceFile: path.resolve(appdir.PATH, 'middleware'),
+            config: {
+              phase: 'routes',
+              params: {
+                key: 'initial value'
+              }
+            }
+          },
+          {
+            sourceFile: path.resolve(appdir.PATH, 'middleware'),
+            config: {
+              phase: 'routes',
+              params: {
+                key: 'custom value'
+              }
+            }
+          }
+        ]);
+    }
+
+    it('merges config.params array to array', function() {
+      appdir.writeConfigFileSync('./middleware.json', {
+        routes: {
+          './middleware': [{
+            params: {
+              key: 'initial value'
+            }
+          }]
+        }
+      });
+
+      appdir.writeConfigFileSync('./middleware.local.json', {
+        routes: {
+          './middleware': [{
+            params: {
+              key: 'custom value'
+            }
+          }]
+        }
+      });
+
+      verifyMiddlewareConfig();
+    });
+
+    it('merges config.params array to object', function() {
+      appdir.writeConfigFileSync('./middleware.json', {
+        routes: {
+          './middleware': {
+            params: {
+              key: 'initial value'
+            }
+          }
+        }
+      });
+
+      appdir.writeConfigFileSync('./middleware.local.json', {
+        routes: {
+          './middleware': [{
+            params: {
+              key: 'custom value'
+            }
+          }]
+        }
+      });
+
+      verifyMiddlewareConfig();
+    });
+
+    it('merges config.params object to array', function() {
+      appdir.writeConfigFileSync('./middleware.json', {
+        routes: {
+          './middleware': [{
+            params: {
+              key: 'initial value'
+            }
+          }]
+        }
+      });
+
+      appdir.writeConfigFileSync('./middleware.local.json', {
+        routes: {
+          './middleware': {
+            params: {
+              key: 'custom value'
+            }
+          }
+        }
+      });
+
+      verifyMiddlewareConfig();
+    });
+
+    it('merges config.params array to empty object', function() {
+      appdir.writeConfigFileSync('./middleware.json', {
+        routes: {
+          './middleware': {}
+        }
+      });
+
+      appdir.writeConfigFileSync('./middleware.local.json', {
+        routes: {
+          './middleware': [{
+            params: {
+              key: 'custom value'
+            }
+          }]
+        }
+      });
+
+      var instructions = boot.compile(appdir.PATH);
+
+      expect(instructions.middleware.middleware)
+        .to.eql([
+          {
+            sourceFile: path.resolve(appdir.PATH, 'middleware'),
+            config: {
+              phase: 'routes',
+              params: {
+                key: 'custom value'
+              }
+            }
+          }
+        ]);
+    });
+
     it('flattens sub-phases', function() {
       appdir.writeConfigFileSync('middleware.json', {
         'initial:after': {


### PR DESCRIPTION
/to @bajtos 

This PR allows the middleware config merge between object and array formats.
```
'./middleware': {...}
'./middleware': [...]
```