### PR TITLE
Resolve ${var} values in middleware.json

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -316,8 +316,48 @@ function setupMiddleware(app, instructions) {
     }
     assert(typeof factory === 'function',
       'Middleware factory must be a function');
+    data.config = getUpdatedConfigObject(data.config, app);
     app.middlewareFromConfig(factory, data.config);
   });
+}
+
+function getUpdatedConfigObject(config, app) {
+
+  var DYNAMIC_CONFIG_PARAM = /\$\{(\w+)\}$/;
+
+  function getConfigVariable(param) {
+    var configVariable = param;
+    var match = configVariable.match(DYNAMIC_CONFIG_PARAM);
+    if (match) {
+      var appValue = app.get(match[1]);
+      if (appValue !== undefined) {
+        configVariable = appValue;
+      } else {
+        console.warn('%s does not resolve to a valid value. ' +
+        '"%s" must be resolvable by app.get().', param, match[1]);
+      }
+    }
+    return configVariable;
+  }
+
+  function interpolateVariables(config) {
+    var interpolated = {};
+    Object.keys(config).forEach(function(configKey) {
+      var value = config[configKey];
+      if (Array.isArray(value)) {
+        interpolated[configKey] = value.map(getConfigVariable);
+      } else if (typeof value === 'string') {
+        interpolated[configKey] = getConfigVariable(value);
+      } else if (typeof value === 'object' && Object.keys(value).length) {
+        interpolated[configKey] = interpolateVariables(value);
+      } else {
+        interpolated[configKey] = value;
+      }
+    });
+    return interpolated;
+  }
+
+  return interpolateVariables(config);
 }
 
 function setupComponents(app, instructions) {

--- a/test/fixtures/simple-middleware.js
+++ b/test/fixtures/simple-middleware.js
@@ -1,0 +1,5 @@
+module.exports = function(params) {
+  return function(req, res, next) {
+    res.send(params);
+  };
+};


### PR DESCRIPTION
Declaratively load **loopback.rest** using `middleware.json`:

```
{
  "routes": {
    "loopback#rest": {
      "paths": ["${restApiRoot}"]
    }
  }
}
```

Connect to strongloop/loopback-boot#75