### PR TITLE
test: fix strict mode failure

### DIFF
--- a/test/browser.multiapp.test.js
+++ b/test/browser.multiapp.test.js
@@ -55,7 +55,6 @@ describe('browser support for multiple apps', function() {
 
 function browserifyTestApps(apps, next) {
   var b = browserify({
-    basedir: appDir,
     debug: true
   });
 


### PR DESCRIPTION
Since the value is undefined at the this point, just remove it so that
linters and strict mode don't cause the entire test suite to abort.