### PR TITLE
Support bluemix environment variables for host and port

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -93,6 +93,7 @@ function setHost(app, instructions) {
     process.env.npm_config_host ||
     process.env.OPENSHIFT_SLS_IP ||
     process.env.OPENSHIFT_NODEJS_IP ||
+    process.env.VCAP_APP_HOST ||
     process.env.HOST ||
     instructions.config.host ||
     process.env.npm_package_config_host ||
@@ -110,6 +111,7 @@ function setPort(app, instructions) {
     process.env.npm_config_port,
     process.env.OPENSHIFT_SLS_PORT,
     process.env.OPENSHIFT_NODEJS_PORT,
+    process.env.VCAP_APP_PORT,
     process.env.PORT,
     instructions.config.port,
     process.env.npm_package_config_port,

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -340,12 +340,14 @@ describe('executor', function() {
       delete process.env.npm_config_host;
       delete process.env.OPENSHIFT_SLS_IP;
       delete process.env.OPENSHIFT_NODEJS_IP;
+      delete process.env.VCAP_APP_HOST;
       delete process.env.HOST;
       delete process.env.npm_package_config_host;
 
       delete process.env.npm_config_port;
       delete process.env.OPENSHIFT_SLS_PORT;
       delete process.env.OPENSHIFT_NODEJS_PORT;
+      delete process.env.VCAP_APP_PORT;
       delete process.env.PORT;
       delete process.env.npm_package_config_port;
     });
@@ -375,6 +377,7 @@ describe('executor', function() {
       assertHonored('npm_config_port', 'npm_config_host');
       assertHonored('npm_package_config_port', 'npm_package_config_host');
       assertHonored('OPENSHIFT_SLS_PORT', 'OPENSHIFT_SLS_IP');
+      assertHonored('VCAP_APP_PORT', 'VCAP_APP_HOST');
       assertHonored('PORT', 'HOST');
     });
 
@@ -383,6 +386,7 @@ describe('executor', function() {
       process.env.npm_config_host = randomHost();
       process.env.OPENSHIFT_SLS_IP = randomHost();
       process.env.OPENSHIFT_NODEJS_IP = randomHost();
+      process.env.VCAP_APP_HOST = randomHost();
       process.env.HOST = randomHost();
       process.env.npm_package_config_host = randomHost();
 
@@ -394,6 +398,7 @@ describe('executor', function() {
       process.env.npm_config_port = randomPort();
       process.env.OPENSHIFT_SLS_PORT = randomPort();
       process.env.OPENSHIFT_NODEJS_PORT = randomPort();
+      process.env.VCAP_APP_PORT = randomPort();
       process.env.PORT = randomPort();
       process.env.npm_package_config_port = randomPort();
 


### PR DESCRIPTION
Detect Bluemix/CouldFoundry environment and automatically apply host/port settings from the environment variables.

See https://github.com/strongloop/loopback/issues/782

/to @kraman or @sam-github please review
/cc @jasnell