### PR TITLE
Bluemix favors PORT over VCAP_APP_PORT

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -93,8 +93,8 @@ function setHost(app, instructions) {
     process.env.npm_config_host ||
     process.env.OPENSHIFT_SLS_IP ||
     process.env.OPENSHIFT_NODEJS_IP ||
-    process.env.VCAP_APP_HOST ||
     process.env.HOST ||
+    process.env.VCAP_APP_HOST ||
     instructions.config.host ||
     process.env.npm_package_config_host ||
     app.get('host');
@@ -111,8 +111,8 @@ function setPort(app, instructions) {
     process.env.npm_config_port,
     process.env.OPENSHIFT_SLS_PORT,
     process.env.OPENSHIFT_NODEJS_PORT,
-    process.env.VCAP_APP_PORT,
     process.env.PORT,
+    process.env.VCAP_APP_PORT,
     instructions.config.port,
     process.env.npm_package_config_port,
     app.get('port'),


### PR DESCRIPTION
VCAP_APP_PORT is soon to be deprecated; PORT is also set by Bluemix. PORT is also generally favored over VCAP_APP_PORT in most Bluemix apps.