### PR TITLE
executor: preserve RegExps in middleware paths

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -354,6 +354,10 @@ function getUpdatedConfigObject(app, config) {
     if (Array.isArray(config))
       return config.map(interpolateVariables);
 
+    // Not a plain object. Examples: RegExp, Date,
+    if (!config.constructor || config.constructor !== Object)
+      return config;
+
     // recurse into object props
     var interpolated = {};
     Object.keys(config).forEach(function(configKey) {


### PR DESCRIPTION
Fix interpolateVariables() to skip objects with a non-default constructor, for example RegExp or Date.

I have discovered this bug while working on https://github.com/strongloop-internal/scrum-loopback/issues/556. Possibly related to https://github.com/strongloop/loopback/issues/1032

/to @raymondfeng please review.