### PR TITLE
Warn about missing main json config file

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -89,6 +89,10 @@ function loadNamed(rootDir, env, name, mergeFn) {
  */
 function findConfigFiles(appRootDir, env, name) {
   var master = ifExists(name + '.json');
+  if (!master && (ifExistsWithAnyExt(name + '.local') ||
+    ifExistsWithAnyExt(name + '.' + env))) {
+    console.warn('WARNING: Main config file "' + name + '.json" is missing');
+  }
   if (!master) return [];
 
   var candidates = [


### PR DESCRIPTION
Added a warning if main config file is missing
Related issue: https://github.com/strongloop/loopback-boot/issues/82

NOTE: If you are missing the main config file, you don't get your config.env.js or config.env.json, where env is the value of NODE_ENV. Is this an expected behavior?