### PR TITLE
When config is overriden with null don't merge

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -266,7 +266,7 @@ function mergeSingleItemOrProperty(target, config, key, fullKey) {
     return mergeArrays(origValue, newValue, fullKey);
   }
 
-  if (typeof origValue === 'object') {
+  if (newValue !== null && typeof origValue === 'object') {
     return mergeObjects(origValue, newValue, fullKey);
   }
 

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -756,6 +756,24 @@ describe('executor', function() {
       appdir.resolve('components/test-component/index.js'));
   });
 
+  it('disable component if overrided by production configuration', function() {
+    appdir.writeConfigFileSync('component-config.json', {
+      './components/test-component': {}
+    });
+    appdir.writeConfigFileSync('component-config.production.json', {
+      './components/test-component': null
+    });
+
+    appdir.writeFileSync('components/test-component/index.js',
+      'module.exports = ' +
+      'function(app, options) { app.componentOptions = options; }');
+
+    boot(app, { appRootDir: appdir.PATH, env: 'production' });
+
+    expect(Object.keys(require.cache)).to.not.include(
+      appdir.resolve('components/test-component/index.js'));
+  });
+
   it('configures middleware (that requires `this`)', function(done) {
     var passportPath = require.resolve('./fixtures/passport');
 


### PR DESCRIPTION
Fixes #146 and also fixes strongloop/loopback-component-explorer#51