### PR TITLE
Modified mergeArrays function to accept arrays of different length.

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -291,6 +291,7 @@ function mergeArrays(target, config, keyPrefix) {
 
 function mergeArraysDiffLength(target, config) {
   var newTarget = _.cloneDeep(target, true);
+  //modifies the target array with the union of both the target and config arrays.
   Array.prototype.splice.apply(target, [0, target.length].concat(_.union(newTarget, config)));
 }
 

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var debug = require('debug')('loopback:boot:config-loader');
 var assert = require('assert');
-
+var _=require('lodash');
 var ConfigLoader = exports;
 
 /**
@@ -276,8 +276,7 @@ function mergeSingleItemOrProperty(target, config, key, fullKey) {
 
 function mergeArrays(target, config, keyPrefix) {
   if (target.length !== config.length) {
-    return 'Cannot merge array values of different length' +
-      ' for the option `' + keyPrefix + '`.';
+    return mergeArraysDiffLength(target, config);
   }
 
   // Use for(;;) to iterate over undefined items, for(in) would skip them.
@@ -289,6 +288,12 @@ function mergeArrays(target, config, keyPrefix) {
 
   return null; // no error
 }
+
+function mergeArraysDiffLength(target, config) {
+  var newTarget = _.cloneDeep(target, true);
+  Array.prototype.splice.apply(target, [0, target.length].concat(_.union(newTarget, config)));
+}
+
 
 function hasCompatibleType(origValue, newValue) {
   if (origValue === null || origValue === undefined)

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var debug = require('debug')('loopback:boot:config-loader');
 var assert = require('assert');
-var _=require('lodash');
+var _ = require('lodash');
 var ConfigLoader = exports;
 
 /**

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -294,7 +294,6 @@ function mergeArraysDiffLength(target, config) {
   Array.prototype.splice.apply(target, [0, target.length].concat(_.union(newTarget, config)));
 }
 
-
 function hasCompatibleType(origValue, newValue) {
   if (origValue === null || origValue === undefined)
     return true;

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var debug = require('debug')('loopback:boot:config-loader');
 var assert = require('assert');
-var _ = require('lodash');
+var lodash = require('lodash');
 var ConfigLoader = exports;
 
 /**
@@ -290,9 +290,11 @@ function mergeArrays(target, config, keyPrefix) {
 }
 
 function mergeArraysDiffLength(target, config) {
-  var newTarget = _.cloneDeep(target, true);
-  //modifies the target array with the union of both the target and config arrays.
-  Array.prototype.splice.apply(target, [0, target.length].concat(_.union(newTarget, config)));
+  var newTarget = lodash.cloneDeep(target, true);
+  //union of both the target and config arrays.
+  var union = lodash.union(newTarget, config);
+  //modifies the target array with the union.
+  Array.prototype.splice.apply(target, [0, target.length].concat(union));
 }
 
 function hasCompatibleType(origValue, newValue) {

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -2,7 +2,8 @@ var fs = require('fs');
 var path = require('path');
 var debug = require('debug')('loopback:boot:config-loader');
 var assert = require('assert');
-var lodash = require('lodash');
+var _ = require('lodash');
+
 var ConfigLoader = exports;
 
 /**
@@ -290,9 +291,9 @@ function mergeArrays(target, config, keyPrefix) {
 }
 
 function mergeArraysDiffLength(target, config) {
-  var newTarget = lodash.cloneDeep(target, true);
+  var newTarget = _.cloneDeep(target, true);
   // Union of both the target and config arrays.
-  var union = lodash.union(newTarget, config);
+  var union = _.union(newTarget, config);
   // Modifies the target array with the union.
   Array.prototype.splice.apply(target, [0, target.length].concat(union));
 }

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -291,9 +291,9 @@ function mergeArrays(target, config, keyPrefix) {
 
 function mergeArraysDiffLength(target, config) {
   var newTarget = lodash.cloneDeep(target, true);
-  //union of both the target and config arrays.
+  // Union of both the target and config arrays.
   var union = lodash.union(newTarget, config);
-  //modifies the target array with the union.
+  // Modifies the target array with the union.
   Array.prototype.splice.apply(target, [0, target.length].concat(union));
 }
 


### PR DESCRIPTION
Modified mergeArrays function to accept arrays of different length and merge the content of arrays.
Useful when you have some dev specific models for dev env as follows

model-config.json

```javascript
{
    "_meta": {
        "sources": [
            "loopback/common/models",
            "loopback/server/models",
            "../common/models"
        ],
        "mixins": [
            "loopback/common/mixins",
            "loopback/server/mixins"
        ]
    },
   "model1": {
    "dataSource": "db",
    "public": true
  },
...
}
```


model-config.dev.json
```javascript
{
    "_meta": {
        "sources": [
            "loopback/common/models",
            "loopback/server/models",
            "../common/models",
            "../devmodels/models"
        ],
        "mixins": [
            "loopback/common/mixins",
            "loopback/server/mixins"
        ]
    },
   "devmodel1": {
    "dataSource": "db",
    "public": true
  },
...
}
```

In such cases it would give you merged array which contain both settings.