### PR TITLE
Dynamic configuration

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -171,6 +171,10 @@ function applyAppConfig(app, instructions) {
 
 function setupDataSources(app, instructions) {
   forEachKeyedObject(instructions.dataSources, function(key, obj) {
+    var opts = {
+      useEnvVars: true,
+    };
+    obj = getUpdatedConfigObject(app, obj, opts);
     app.dataSource(key, obj);
   });
 }
@@ -330,24 +334,42 @@ function setupMiddleware(app, instructions) {
     }
     assert(typeof factory === 'function',
       'Middleware factory must be a function');
-    data.config = getUpdatedConfigObject(app, data.config);
+    var opts = {
+      useEnvVars: true,
+    };
+    data.config = getUpdatedConfigObject(app, data.config, opts);
     app.middlewareFromConfig(factory, data.config);
   });
 }
 
-function getUpdatedConfigObject(app, config) {
+function getUpdatedConfigObject(app, config, opts) {
   var DYNAMIC_CONFIG_PARAM = /\$\{(\w+)\}$/;
+  var useEnvVars = opts && opts.useEnvVars;
 
   function getConfigVariable(param) {
     var configVariable = param;
     var match = configVariable.match(DYNAMIC_CONFIG_PARAM);
     if (match) {
-      var appValue = app.get(match[1]);
-      if (appValue !== undefined) {
+      var varName = match[1];
+      if (useEnvVars && process.env[varName] !== undefined) {
+        debug('Dynamic Configuration: Resolved via process.env: %s as %s',
+          process.env[varName], param);
+        configVariable = process.env[varName];
+      } else if (app.get(varName) !== undefined) {
+        debug('Dynamic Configuration: Resolved via app.get(): %s as %s',
+          app.get(varName), param);
+        var appValue = app.get(varName);
         configVariable = appValue;
       } else {
-        console.warn('%s does not resolve to a valid value. ' +
-        '"%s" must be resolvable by app.get().', param, match[1]);
+        // previously it returns the original string such as "${restApiRoot}"
+        // it will now return `undefined`, for the use case of
+        // dynamic datasources url:`undefined` to fallback to other parameters
+        configVariable = undefined;
+        console.warn('%s does not resolve to a valid value, returned as %s. ' +
+        '"%s" must be resolvable in Environment variable or by app.get().',
+          param, configVariable, varName);
+        debug('Dynamic Configuration: Cannot resolve variable for `%s`, ' +
+          'returned as %s', varName, configVariable);
       }
     }
     return configVariable;
@@ -394,7 +416,10 @@ function setupComponents(app, instructions) {
   instructions.components.forEach(function(data) {
     debug('Configuring component %j', data.sourceFile);
     var configFn = require(data.sourceFile);
-    data.config = getUpdatedConfigObject(app, data.config);
+    var opts = {
+      useEnvVars: true,
+    };
+    data.config = getUpdatedConfigObject(app, data.config, opts);
     configFn(app, data.config);
   });
 }


### PR DESCRIPTION
connect to strongloop/loopback-boot/issues/4
### Implementation: 
This uses the original implementation of **dynamic configuration** of middleware that reads from `server/config.json`, and now takes `ENV VAR` precedence over `app.get()` 

------------
datasources will now handle dynamic configuration such as
```
{
  "mysql" : {
    "name" : "mysql_db",
    "host" : "${MYSQL_DB_HOST}",
    ...
  }
}
```
and you will be able to provide the parameter through
  ENV such as
    `MYSQL_DB_HOST=127.0.0.1 node .`
  server/config.json
```
  {
    "MYSQL_DB_HOST": "127.0.0.1"
  }
```




### Following will be implemented and addressed in a different task 

>Need to handle scenario
----------------------
- [ ] ability for dev to easily handle prefix'ed(or however its processed)  **ENV** var (bluemix/heroku/..etc) 
- [ ] any concerns for us to make a config file becoming a template?
- [ ] ability to use **cloud provided** env-var data 
### deployment platform will prefix env-vars?
`MYSQL_HOST=127.0.0.1 node .`
but in deployment env 
```
//process.env 
{
  "VCAP_MYSQL_HOST": "127.0.0.1",
.....
}
```
### using env-var data from cloud-platoforms that is not primitive data
>You can use your VCAP_SERVICES environment variable to retrieve the information and credentials you need to access the SQL Database service with various Bluemix runtimes.
https://console.ng.bluemix.net/docs/services/SQLDB/index.html#vcap-free
```
{
  "sqldb": [
    {
      "name": "mydb",
      "label": "sqldb",
      "plan": "sqldb_free",
      "credentials": {
        "port": 50000,
        "db": "SQLDB",
        "username": "xxxxxxx",
        "host": "75.126.155.92",
        "hostname": "75.126.155.92",
        "jdbcurl": "jdbc:db2://75.126.155.92:50000/SQLDB",
        "uri": "db2://xxxxxxx:xxxxxxx@75.126.155.92:50000/SQLDB",
        "password": "xxxxxxx"
      }
    }
  ]
}
```
For this we will need the ability to resolve more than just a string from **env var** and **config.json** but need logic to handle objects or functions


