### PR TITLE
parse config: should ignore null values

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -400,6 +400,8 @@ function getUpdatedConfigObject(app, config, opts) {
         interpolated[configKey] = value.map(interpolateVariables);
       } else if (typeof value === 'string') {
         interpolated[configKey] = getConfigVariable(value);
+      } else if (value === null) {
+        interpolated[configKey] = value;
       } else if (typeof value === 'object' && Object.keys(value).length) {
         interpolated[configKey] = interpolateVariables(value);
       } else {

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -543,6 +543,23 @@ describe('executor', function() {
       });
     });
 
+    it('should parse config variables with null values', function(done) {
+      boot.execute(app, simpleMiddlewareConfig('routes',
+        { nested: { info: { path: '${restApiRoot}', some: null }}}
+      ));
+
+      supertest(app).get('/').end(function(err, res) {
+        if (err) return done(err);
+        expect(res.body.nested).to.eql({
+          info: {
+            path: app.get('restApiRoot'),
+            some: null,
+          },
+        });
+        done();
+      });
+    });
+
     it('should not parse invalid config variables', function(done) {
       var invalidDataTypes = [undefined, function() {}];
       async.each(invalidDataTypes, function(invalidDataType, cb) {


### PR DESCRIPTION
Fix #182