### PR TITLE
executor: allow to boot loopback without remotes

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -308,7 +308,8 @@ function runScripts(app, list, callback) {
 }
 
 function setupMiddleware(app, instructions) {
-  if (!instructions.middleware) {
+  if (!instructions.middleware ||
+    typeof app.defineMiddlewarePhases !== 'function') {
     // the browserified client does not support middleware
     return;
   }
@@ -429,6 +430,7 @@ function runBootScripts(app, instructions, callback) {
 }
 
 function enableAnonymousSwagger(app, instructions) {
+  if (typeof app.remotes !== 'function') return;
   // disable token requirement for swagger, if available
   var swagger = app.remotes().exports.swagger;
   if (!swagger) return;


### PR DESCRIPTION
Hi StrongLoop community, I created another loopback runtime which doesn't have remote objects, of course no middleware and phases will be defined there, I also wanna use loopback-boot to boot that application, but occurred some errors on checking/assertions in this repository.

Created this PR to fix what I have met :-)
Another runtime of loopback-similar is at https://github.com/weflex/pancake-agent