### PR TITLE
Remove `defaultForType` option from tests

### DIFF
--- a/test/compiler.test.js
+++ b/test/compiler.test.js
@@ -39,7 +39,6 @@ describe('compiler', function() {
         dataSources: {
           'the-db': {
             connector: 'memory',
-            defaultForType: 'db',
           },
         },
       };

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -806,7 +806,7 @@ describe('executor', function() {
         expect(res.text).to.eql(('<!DOCTYPE html>\n<html>\n<head lang="en">\n' +
           '    <meta charset="UTF-8">\n    <title>simple-app</title>\n' +
           '</head>\n<body>\n<h1>simple-app</h1>\n' +
-          '</body>\n</html>').replace(/\n/g, /(\r\n)|(\n)|(\r)/));
+          '</body>\n</html>'));
         done();
       });
   });

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -55,7 +55,6 @@ describe('executor', function() {
     dataSources: {
       'the-db': {
         connector: 'memory',
-        defaultForType: 'db',
       },
     },
   });

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -803,10 +803,11 @@ describe('executor', function() {
       .get('/')
       .end(function(err, res) {
         if (err) return done(err);
-        expect(res.text).to.eql(('<!DOCTYPE html>\n<html>\n<head lang="en">\n' +
+        expect(res.text).to.match(new RegExp(
+          '<!DOCTYPE html>\n<html>\n<head lang="en">\n' +
           '    <meta charset="UTF-8">\n    <title>simple-app</title>\n' +
           '</head>\n<body>\n<h1>simple-app</h1>\n' +
-          '</body>\n</html>'));
+          '</body>\n</html>'.replace('\n', '(\r\n)|(\n)|(\r)')));
         done();
       });
   });

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -806,7 +806,7 @@ describe('executor', function() {
         expect(res.text).to.eql(('<!DOCTYPE html>\n<html>\n<head lang="en">\n' +
           '    <meta charset="UTF-8">\n    <title>simple-app</title>\n' +
           '</head>\n<body>\n<h1>simple-app</h1>\n' +
-          '</body>\n</html>').replace(/\n/g, os.EOL));
+          '</body>\n</html>').replace(/\n/g, /(\r\n)|(\n)|(\r)/));
         done();
       });
   });

--- a/test/helpers/appdir.js
+++ b/test/helpers/appdir.js
@@ -32,7 +32,6 @@ appdir.createConfigFilesSync = function(appConfig, dataSources, models) {
   dataSources = extend({
     db: {
       connector: 'memory',
-      defaultForType: 'db',
     },
   }, dataSources);
   appdir.writeConfigFileSync ('datasources.json', dataSources);


### PR DESCRIPTION
https://github.com/strongloop/loopback-boot/pull/214

this option has been deprecated since 2.x
tests already explicitly attach to datasources
autoattach was removed in strongloop/loopback#1989