### PR TITLE
Fix resolution of middleware modules [2.x]

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -569,7 +569,7 @@ function resolveMiddlewarePath(rootDir, middleware, config) {
 
   // Try to require the module and check if <module>.<fragment> is a valid
   // function
-  var m = require(pathName);
+  var m = require(sourceFile);
   if (typeof m[fragment] === 'function') {
     resolved.sourceFile = sourceFile;
     return resolved;


### PR DESCRIPTION
Fix the code loading "loopback#errorhandler" (for example) to correctly look up the "loopback" module in node_modules of the bootstrapped application, instead of looking it up in node_modules of loopback-boot.

Note that I am intentionally not including any unit-tests, because setting up a correct directory layout reproducing the problem is too difficult.

@davidcheung please review.

I am intentionally sending the PR against the 2.x branch, please forward-port it to your refactor pull request #181.

cc @kraman This should fix the issue you reported in our chat.
cc @raymondfeng 