### PR TITLE
adds support for absolute middleware paths on win32

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -381,7 +381,10 @@ function tryResolveAppPath(rootDir, relativePath, resolveOptions) {
   resolveOptions = resolveOptions || { strict: true };
 
   var isModuleRelative = false;
-  if (relativePath[0] === '/') {
+  // would love to use `path.isAbsolute(relativePath)` from node's core module `path`
+  // but unfortunately that is not available in node v0.10.x
+  // https://nodejs.org/dist/latest-v6.x/docs/api/path.html#path_path_isabsolute_path
+  if (relativePath[0] === '/' || /^[a-zA-Z]:[\\]{1,2}/.test(relativePath)) {
     fullPath = relativePath;
   } else if (start === './' || start === '..') {
     fullPath = path.resolve(rootDir, relativePath);

--- a/test/compiler.test.js
+++ b/test/compiler.test.js
@@ -2016,6 +2016,22 @@ describe('compiler', function() {
         .to.equal(require.resolve('loopback/server/middleware/url-not-found'));
     });
 
+    it('supports absolute paths notation', function() {
+      var middlewarePath =
+        path.resolve(__dirname, './fixtures/simple-middleware.js');
+      var routes = {};
+      routes[middlewarePath] = {};
+      appdir.writeConfigFileSync('middleware.json', {
+        'routes': routes,
+      });
+
+      var instructions = boot.compile(appdir.PATH);
+
+      expect(instructions.middleware.middleware[0].sourceFile)
+        .to.equal(path.resolve(appdir.PATH,
+          middlewarePath));
+    });
+
     it('supports shorthand notation for relative paths', function() {
       appdir.writeConfigFileSync('middleware.json', {
         'routes': {


### PR DESCRIPTION
uses simple regex check to test if a path matches NTFS notation. Couldn't use `path.isAbsolute` since that was only introduced in node v0.11.2