### PR TITLE
Exclude .map extension

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -661,6 +661,7 @@ function getExcludedExtensions() {
   return {
     '.json': '.json',
     '.node': 'node',
+    '.map': '.map'
   };
 }
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -661,7 +661,7 @@ function getExcludedExtensions() {
   return {
     '.json': '.json',
     '.node': 'node',
-    '.map': '.map'
+    '.map': '.map',
   };
 }
 


### PR DESCRIPTION
### Description
If you are using loopback with typescript or any other javascript dialect, it would generate the .map files for the debugger. loopback-boot tries to load these files which ends up into a Syntax-Error.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #246

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)