### PR TITLE
Support for Typescript/Babel emitted ES2015 modules

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -14,6 +14,7 @@ var debug = require('debug')('loopback:boot:compiler');
 var Module = require('module');
 var _ = require('lodash');
 var g = require('strong-globalize')();
+var requireNodeOrEsModule = require('./require');
 
 var FILE_EXTENSION_JSON = '.json';
 
@@ -589,7 +590,7 @@ function resolveMiddlewarePath(rootDir, middleware, config) {
 
   // Try to require the module and check if <module>.<fragment> is a valid
   // function
-  var m = require(sourceFile);
+  var m = requireNodeOrEsModule(sourceFile);
   if (typeof m[fragment] === 'function') {
     resolved.sourceFile = sourceFile;
     return resolved;
@@ -778,7 +779,7 @@ function loadMixins(sourceFiles, normalization) {
     meta.name = name;
     if (utils.fileExistsSync(metafile)) {
       // May overwrite name, not sourceFile
-      _.extend(meta, require(metafile));
+      _.extend(meta, requireNodeOrEsModule(metafile));
     }
     meta.sourceFile = filepath;
     mixinInstructions[meta.name] = meta;

--- a/lib/executor.js
+++ b/lib/executor.js
@@ -10,6 +10,7 @@ var async = require('async');
 var path = require('path');
 var format = require('util').format;
 var g = require('strong-globalize')();
+var requireNodeOrEsModule = require('./require');
 
 /**
  * Execute bootstrap instructions gathered by `boot.compile`.
@@ -211,7 +212,7 @@ function defineMixins(app, instructions) {
   if (!modelBuilder.mixins || !mixins.length) return;
 
   mixins.forEach(function(obj) {
-    var mixin = require(obj.sourceFile);
+    var mixin = requireNodeOrEsModule(obj.sourceFile);
 
     if (typeof mixin === 'function' || mixin.prototype instanceof BaseClass) {
       debug('Defining mixin %s', obj.name);
@@ -244,7 +245,7 @@ function defineModels(app, instructions) {
       model = registry.createModel(data.definition);
       if (data.sourceFile) {
         debug('Loading customization script %s', data.sourceFile);
-        var code = require(data.sourceFile);
+        var code = requireNodeOrEsModule(data.sourceFile);
         if (typeof code === 'function') {
           debug('Customizing model %s', name);
           code(model);
@@ -288,12 +289,12 @@ function runScripts(app, list, callback) {
   list.forEach(function(filepath) {
     debug('Requiring script %s', filepath);
     try {
-      var exports = require(filepath);
-      if (typeof exports === 'function') {
+      var bootFn = requireNodeOrEsModule(filepath);
+      if (typeof bootFn === 'function') {
         debug('Exported function detected %s', filepath);
         functions.push({
           path: filepath,
-          func: exports,
+          func: bootFn,
         });
       }
     } catch (err) {
@@ -340,7 +341,7 @@ function setupMiddleware(app, instructions) {
   middleware.forEach(function(data) {
     debug('Configuring middleware %j%s', data.sourceFile,
         data.fragment ? ('#' + data.fragment) : '');
-    var factory = require(data.sourceFile);
+    var factory = requireNodeOrEsModule(data.sourceFile);
     if (data.fragment) {
       factory = factory[data.fragment].bind(factory);
     }
@@ -429,7 +430,7 @@ function getUpdatedConfigObject(app, config, opts) {
 function setupComponents(app, instructions) {
   instructions.components.forEach(function(data) {
     debug('Configuring component %j', data.sourceFile);
-    var configFn = require(data.sourceFile);
+    var configFn = requireNodeOrEsModule(data.sourceFile);
     var opts = {
       useEnvVars: true,
     };

--- a/lib/require.js
+++ b/lib/require.js
@@ -1,0 +1,9 @@
+// Copyright IBM Corp. 2015,2017. All Rights Reserved.
+// Node module: loopback-boot
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+module.exports = function requireNodeOrEsModule(sourceFile) {
+  var exports = require(sourceFile);
+  return exports && exports.__esModule ? exports.default : exports;
+};

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -57,10 +57,15 @@ describe('browser support', function() {
       expect(Object.keys(app.models)).to.include('Customer');
       expect(app.models.Customer.settings)
         .to.have.property('_customized', 'Customer');
+      expect(Object.keys(app.models)).to.include('ProductUmd');
+      expect(app.models.ProductUmd.settings)
+        .to.have.property('_customized', 'UMD');
 
-      // configured in fixtures/browser-app/component-config.json
-      // and fixtures/browser-app/components/dummy-component.js
+      // configured in fixtures/browser-app/component-config.json,
+      // fixtures/browser-app/components/dummy-component.js and
+      // fixtures/browser-app/components/dummy-component-umd.js
       expect(app.dummyComponentOptions).to.eql({ option: 'value' });
+      expect(app.dummyComponentUmdOptions).to.eql({ option: 'valueUmd' });
 
       done();
     });
@@ -79,8 +84,9 @@ describe('browser support', function() {
 
       var modelBuilder = app.registry.modelBuilder;
       var registry = modelBuilder.mixins.mixins;
-      expect(Object.keys(registry)).to.eql(['TimeStamps']);
+      expect(Object.keys(registry)).to.eql(['AuditedUmd', 'TimeStamps']);
       expect(app.models.Customer.timeStampsMixin).to.eql(true);
+      expect(app.models.ProductUmd.auditedMixin).to.eql(true);
 
       done();
     });

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -278,6 +278,7 @@ describe('executor', function() {
           'barStarted',
           'barFinished',
           'barSyncExecuted',
+          'umdLoaded',
         ]);
         done();
       }, 10);
@@ -294,6 +295,7 @@ describe('executor', function() {
           'barStarted',
           'barFinished',
           'barSyncExecuted',
+          'umdLoaded',
         ]);
         done();
       });
@@ -838,6 +840,7 @@ describe('executor', function() {
       .end(function(err, res) {
         if (err) return done(err);
         expect(res.headers.names).to.equal('custom-middleware');
+        expect(res.headers.umd).to.equal('success');
         done();
       });
   });

--- a/test/fixtures/browser-app/component-config.json
+++ b/test/fixtures/browser-app/component-config.json
@@ -1,5 +1,8 @@
 {
   "./components/dummy-component": {
     "option": "value"
+  },
+  "./components/dummy-component-umd": {
+    "option": "valueUmd"
   }
 }

--- a/test/fixtures/browser-app/components/dummy-component-umd.js
+++ b/test/fixtures/browser-app/components/dummy-component-umd.js
@@ -1,0 +1,11 @@
+// Copyright IBM Corp. 2015,2017. All Rights Reserved.
+// Node module: loopback-boot
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+module.exports = {
+  default: function(app, options) {
+    app.dummyComponentUmdOptions = options;
+  },
+};
+Object.defineProperty(module.exports, '__esModule', { value: true });

--- a/test/fixtures/browser-app/mixins/audited-umd.js
+++ b/test/fixtures/browser-app/mixins/audited-umd.js
@@ -1,0 +1,11 @@
+// Copyright IBM Corp. 2014,2017. All Rights Reserved.
+// Node module: loopback-boot
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+module.exports = {
+  default: function(Model, options) {
+    Model.auditedMixin = true;
+  },
+};
+Object.defineProperty(module.exports, '__esModule', { value: true });

--- a/test/fixtures/browser-app/model-config.json
+++ b/test/fixtures/browser-app/model-config.json
@@ -7,5 +7,8 @@
   },
   "Customer": {
     "dataSource": "db"
+  },
+  "ProductUmd": {
+    "dataSource": "db"
   }
 }

--- a/test/fixtures/browser-app/models/product-umd.js
+++ b/test/fixtures/browser-app/models/product-umd.js
@@ -1,0 +1,11 @@
+// Copyright IBM Corp. 2014,2017. All Rights Reserved.
+// Node module: loopback-boot
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+module.exports = {
+  default: function(ProductUmd) {
+    ProductUmd.settings._customized = 'UMD';
+  },
+};
+Object.defineProperty(module.exports, '__esModule', { value: true });

--- a/test/fixtures/browser-app/models/product-umd.json
+++ b/test/fixtures/browser-app/models/product-umd.json
@@ -1,0 +1,5 @@
+{
+  "name": "ProductUmd",
+  "base": "User",
+  "mixins": {"AuditedUmd": {} }
+}

--- a/test/fixtures/simple-app/boot/umd.js
+++ b/test/fixtures/simple-app/boot/umd.js
@@ -1,0 +1,11 @@
+// Copyright IBM Corp. 2014,2017. All Rights Reserved.
+// Node module: loopback-boot
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+module.exports = {
+  default: function(app) {
+    process.bootFlags.push('umdLoaded');
+  },
+};
+Object.defineProperty(module.exports, '__esModule', { value: true });

--- a/test/fixtures/simple-app/middleware.json
+++ b/test/fixtures/simple-app/middleware.json
@@ -2,6 +2,9 @@
   "initial": {
     "../../helpers/push-name-middleware": {
       "params": "custom-middleware"
-    }
+    },
+     "../../helpers/set-umd-middleware": {
+       "params": "success"
+     }
   }
 }

--- a/test/helpers/set-umd-middleware.js
+++ b/test/helpers/set-umd-middleware.js
@@ -1,0 +1,14 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: loopback-boot
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+module.exports = {
+  default: function(value) {
+    return function(req, res, next) {
+      res.setHeader('umd', value);
+      next();
+    };
+  },
+};
+Object.defineProperty(module.exports, '__esModule', { value: true });


### PR DESCRIPTION
### Description

Both Typescript and Babel (when run with `modules: false`) emit modules that can be identified as ES2015 by the `__esModule` flag. This PR updates loopback-boot to handle these modules in the following scenarios.

* Executing:
  * Mixin source files
  * Model source files
  * Boot scripts
  * Middleware source files
  * Component source files
* Compiling:
  * Model source files
  * Mixin source files

#### Related issues

- #173 
- #203 is encompassed by this PR.

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
