### PR TITLE
Add support for ES6 style async boot scripts

### DIFF
--- a/lib/plugins/boot-script.js
+++ b/lib/plugins/boot-script.js
@@ -81,23 +81,24 @@ function runScripts(app, list, callback) {
 
   async.eachSeries(functions, function(f, done) {
     debug('Running script %s', f.path);
-    if (f.func.length >= 2) {
-      debug('Starting async function %s', f.path);
-      f.func(app, function(err) {
-        debug('Async function finished %s', f.path);
-        done(err);
-      });
-    } else {
-      debug('Starting sync function %s', f.path);
-      var error;
-      try {
-        f.func(app);
+    var cb = function(err) {
+      debug('Async function %s %s', err ? 'failed' : 'finished', f.path);
+      done(err);
+      // Make sure done() isn't called twice, e.g. if a script returns a
+      // thenable object and also calls the passed callback.
+      cb = function() {};
+    };
+    try {
+      var result = f.func(app, cb);
+      if (result && typeof result.then === 'function') {
+        result.then(function() { cb(); }, cb);
+      } else if (f.func.length < 2) {
         debug('Sync function finished %s', f.path);
-      } catch (err) {
-        debug('Sync function failed %s', f.path, err);
-        error = err;
+        done();
       }
-      done(error);
+    } catch (err) {
+      debug('Sync function failed %s', f.path, err);
+      done(err);
     }
   }, callback);
 }

--- a/test/fixtures/simple-app/boot/promise-callback.js
+++ b/test/fixtures/simple-app/boot/promise-callback.js
@@ -1,0 +1,15 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: loopback-boot
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+var Promise = require('bluebird');
+
+module.exports = function(app, callback) {
+  callback();
+  if (process.promiseAndCallback) {
+    return Promise.reject();
+  }
+};

--- a/test/fixtures/simple-app/boot/promise.js
+++ b/test/fixtures/simple-app/boot/promise.js
@@ -1,0 +1,21 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: loopback-boot
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+var Promise = require('bluebird');
+
+process.bootFlags.push('promiseLoaded');
+module.exports = function(app) {
+  process.bootFlags.push('promiseStarted');
+  return Promise.resolve({
+    then: function(onFulfill, onReject) {
+      process.nextTick(function() {
+        process.bootFlags.push('promiseFinished');
+        onFulfill();
+      });
+    },
+  });
+};

--- a/test/fixtures/simple-app/boot/reject.js
+++ b/test/fixtures/simple-app/boot/reject.js
@@ -1,0 +1,14 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: loopback-boot
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+var Promise = require('bluebird');
+
+module.exports = function(app) {
+  if (process.rejectPromise) {
+    return Promise.reject(new Error('reject'));
+  }
+};

--- a/test/fixtures/simple-app/boot/thenable.js
+++ b/test/fixtures/simple-app/boot/thenable.js
@@ -1,0 +1,19 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: loopback-boot
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+process.bootFlags.push('thenableLoaded');
+module.exports = function(app) {
+  process.bootFlags.push('thenableStarted');
+  return {
+    then: function(onFulfill, onReject) {
+      process.nextTick(function() {
+        process.bootFlags.push('thenableFinished');
+        onFulfill();
+      });
+    },
+  };
+};

--- a/test/fixtures/simple-app/boot/throw.js
+++ b/test/fixtures/simple-app/boot/throw.js
@@ -1,0 +1,12 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: loopback-boot
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+module.exports = function(app) {
+  if (process.throwError) {
+    throw new Error('throw');
+  }
+};


### PR DESCRIPTION
### Description

This PR allows boot scripts to be defined in the ES6 async fashion, without the need for passing callbacks:

```js
module.exports = async function(app) {
   ...
};
```

#### Related issues

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
