### PR TITLE
Do not call callbacks twice in async boot scripts

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -306,11 +306,11 @@ function runScripts(app, list, callback) {
   async.eachSeries(functions, function(f, done) {
     debug('Running script %s', f.path);
     var cb = function(err) {
-      debug('Async function finished %s', f.path);
+      debug('Async function %s %s', err ? 'failed' : 'finished', f.path);
       done(err);
       // Make sure done() isn't called twice, e.g. if a script returns a
       // thenable object and also calls the passed callback.
-      cb = null;
+      cb = function() {};
     };
     try {
       var result = f.func(app, cb);

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -373,6 +373,23 @@ describe('executor', function() {
     });
   });
 
+  describe('with boot script returning a promise and calling callback',
+    function() {
+      before(function() {
+        process.promiseAndCallback = true;
+      });
+
+      after(function() {
+        delete process.promiseAndCallback;
+      });
+
+      it('should only call the callback once', function(done) {
+        // Note: Mocha will fail this test if done() is called twice
+        boot.execute(app, simpleAppInstructions(), done);
+      });
+    }
+  );
+
   describe('for mixins', function() {
     var options;
     beforeEach(function() {

--- a/test/fixtures/simple-app/boot/promise-callback.js
+++ b/test/fixtures/simple-app/boot/promise-callback.js
@@ -1,0 +1,13 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: loopback-boot
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+var Promise = require('bluebird');
+
+module.exports = function(app, callback) {
+  callback();
+  if (process.promiseAndCallback) {
+    return Promise.reject();
+  }
+};


### PR DESCRIPTION
### Description

As discussed in https://github.com/strongloop/loopback-boot/pull/252#issuecomment-319906102, we need to make sure that a boot script that both returns a promise and calls the callback method does not trigger two calls of the callback method passed to `boot.execute()`.

#### Related issues

- #252

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
