### PR TITLE
Ignore js sourcemap files from boot

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -661,6 +661,12 @@ function resolveRelativePaths(relativePaths, appRootDir) {
 function getExcludedExtensions() {
   return {
     '.json': '.json',
+    /**
+     * This is a temporary workaround for #246
+     * See discussion here for full description of the underlying issue
+     * https://github.com/strongloop/loopback-boot/pull/245#issuecomment-311052798
+     */
+    '.map': '.map',
     '.node': 'node',
   };
 }

--- a/test/compiler.test.js
+++ b/test/compiler.test.js
@@ -2187,6 +2187,24 @@ describe('compiler', function() {
         'sourceFile', coffee);
     });
 
+    it('ignores sourcmap files when loading middleware',
+    function() {
+      var middleware = appdir.writeFileSync('my-middleware.js',
+        '// I am the middleware');
+      var sourcemap = appdir.writeFileSync('my-middleware.js.map',
+        '// I am a sourcemap');
+      appdir.writeConfigFileSync('middleware.json', {
+        'routes': {
+          './my-middleware': {},
+        },
+      });
+
+      var instructions = boot.compile(appdir.PATH);
+
+      expect(instructions.middleware.middleware[0]).have.property(
+        'sourceFile', middleware);
+    });
+
     describe('config with relative paths in params', function() {
       var RELATIVE_PATH_PARAMS = [
         '$!./here',


### PR DESCRIPTION
### Description

See discussion from #256  and #245

#### Related issues

- #255

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

cc @bajtos 