### PR TITLE
Add CODEOWNERS to 2.x branch

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners,
+# the last matching pattern has the most precendence.
+
+* @bajtos @lehni


### PR DESCRIPTION
While reviewing #263, I noticed that CODEOWNERS are not used for that branch. In this pull request I am assigning myself as the codeowner, together with @lehni who is listed in CODEOWNERS for `master`.

@raymondfeng You are listed in CODEOWNERS for the `master` branch because you are more familiar with it than I am. For `2.x`, I am happy to act as code owner myself, so that you don't have to. But if you like to, then let me know and I'll add you too 😄 