### PR TITLE
update strong-globalize to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "debug": "^2.0.0",
     "lodash": "^3.6.0",
     "semver": "^4.1.0",
-    "strong-globalize": "^2.6.2",
+    "strong-globalize": "^3.1.0",
     "toposort": "^0.2.10"
   },
   "devDependencies": {


### PR DESCRIPTION
Testing whether the 2.x branch works with the latest version of strong-globalize

- connect to update strong-globalize to 3.1.0 #268
