### PR TITLE
CODEOWNERS: move @lehni to Alumni section

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,10 @@
 # Each line is a file pattern followed by one or more owners,
 # the last matching pattern has the most precendence.
 
-* @raymondfeng @lehni @zbarbuto
+# Current maintainers
+
+* @raymondfeng @zbarbuto
+
+# Alumni
+#
+# @lehni


### PR DESCRIPTION
Effectively remove Jurg from the list of code owners assigned to review pull requests.