### PR TITLE
Upgrade lodash from 3.x to 4.x [loopback-boot@2.x]

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -469,7 +469,7 @@ function tryResolveAppPath(rootDir, relativePath, resolveOptions) {
 function loadModelDefinition(rootDir, jsonFile, allFiles, scriptExtensions) {
   var definition = require(jsonFile);
   var basename = path.basename(jsonFile, path.extname(jsonFile));
-  definition.name = definition.name || _.capitalize(_.camelCase(basename));
+  definition.name = definition.name || _.upperFirst(_.camelCase(basename));
 
   // find a matching file with a supported extension like `.js` or `.coffee`
   var sourceFile = fixFileExtension(jsonFile, allFiles, scriptExtensions);
@@ -626,7 +626,7 @@ function resolveMiddlewarePath(rootDir, middleware, config) {
 var MIDDLEWARE_PATH_PARAM_REGEX = /^\$!(\.\/|\.\.\/)/;
 
 function resolveMiddlewareParams(rootDir, params) {
-  return cloneDeep(params, function resolvePathParam(value) {
+  return _.cloneDeepWith(params, function resolvePathParam(value) {
     if (typeof value === 'string' && MIDDLEWARE_PATH_PARAM_REGEX.test(value)) {
       return path.resolve(rootDir, value.slice(2));
     } else {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "async": "~0.9.0",
     "commondir": "0.0.1",
     "debug": "^2.0.0",
-    "lodash": "^3.6.0",
+    "lodash": "^4.17.5",
     "semver": "^4.1.0",
     "strong-globalize": "^2.6.2",
     "toposort": "^0.2.10"


### PR DESCRIPTION
This pull request fixes the following security vulnerability reported by Snyk:

- [npm:lodash:20180130](https://snyk.io/vuln/npm:lodash:20180130) - potentially breaking change
