### PR TITLE
chore: upgrade deps to avoid npm audit warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,25 +29,25 @@
   "license": "MIT",
   "dependencies": {
     "async": "^2.4.0",
-    "bluebird": "^3.4.0",
+    "bluebird": "^3.5.3",
     "commondir": "^1.0.1",
-    "debug": "^2.2.0",
+    "debug": "^4.1.1",
     "lodash": "^4.17.11",
     "semver": "^5.1.0",
     "strong-globalize": "^4.1.1",
     "toposort": "^2.0.2"
   },
   "devDependencies": {
-    "browserify": "^4.2.3",
-    "chai": "^3.5.0",
+    "browserify": "^16.2.3",
+    "chai": "^4.2.0",
+    "coffeeify": "^3.0.1",
     "coffeescript": "^2.3.1",
-    "coffeeify": "^2.0.1",
-    "dirty-chai": "^1.2.2",
+    "dirty-chai": "^2.0.1",
     "eslint": "^5.2.0",
     "eslint-config-loopback": "^11.0.0",
-    "fs-extra": "^3.0.1",
+    "fs-extra": "^7.0.1",
     "loopback": "^3.0.0",
     "mocha": "^5.2.0",
-    "supertest": "^3.0.0"
+    "supertest": "^4.0.2"
   }
 }

--- a/test/helpers/browser.js
+++ b/test/helpers/browser.js
@@ -10,7 +10,8 @@ var vm = require('vm');
 function createContext() {
   var context = {
     // required by browserify
-    XMLHttpRequest: function() { throw new Error('not implemented'); },
+    XMLHttpRequest: function() {},
+    clearTimeout: function() {},
     FormData: function() { throw new Error('not implemented'); },
 
     localStorage: {


### PR DESCRIPTION
### Description

Upgrade deps to remove `npm audit` warnings.

#### Related issues

#288 

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
