### PR TITLE
Tag 2.x versions as `lts` in npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "loopback-boot",
   "version": "2.28.0",
+  "publishConfig": {
+    "tag": "lts"
+  },
   "description": "Convention-based bootstrapper for LoopBack applications",
   "keywords": [
     "StrongLoop",


### PR DESCRIPTION
See also https://github.com/strongloop/loopback-boot/pull/293