### PR TITLE
test: fix browserify-based tests

### DIFF
--- a/test/browser.multiapp.test.js
+++ b/test/browser.multiapp.test.js
@@ -8,6 +8,7 @@
 var boot = require('../');
 var async = require('async');
 var exportBrowserifyToFile = require('./helpers/browserify').exportToSandbox;
+var packageFilter = require('./helpers/browserify').packageFilter;
 var fs = require('fs');
 var path = require('path');
 var expect = require('chai').expect;
@@ -66,6 +67,7 @@ function browserifyTestApps(apps, next) {
   var b = browserify({
     debug: true,
     basedir: path.resolve(__dirname, './fixtures'),
+    packageFilter,
   });
 
   var bundles = [];

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -7,6 +7,7 @@
 
 var boot = require('../');
 var exportBrowserifyToFile = require('./helpers/browserify').exportToSandbox;
+var packageFilter = require('./helpers/browserify').packageFilter;
 var fs = require('fs');
 var path = require('path');
 var expect = require('chai').expect;
@@ -21,6 +22,7 @@ var compileStrategies = {
     var b = browserify({
       basedir: appDir,
       debug: true,
+      packageFilter,
     });
     b.require('./app.js', {expose: 'browser-app'});
     return b;
@@ -31,6 +33,7 @@ var compileStrategies = {
       basedir: appDir,
       extensions: ['.coffee'],
       debug: true,
+      packageFilter,
     });
     b.transform('coffeeify');
 

--- a/test/helpers/browserify.js
+++ b/test/helpers/browserify.js
@@ -21,3 +21,16 @@ function exportToSandbox(b, fileName, callback) {
   });
 }
 exports.exportToSandbox = exportToSandbox;
+
+exports.packageFilter = function packageFilter(pkg, dir) {
+  // async@3 (used e.g. by loopback-connector) is specifying custom
+  // browserify config, in particular it wants to apply transformation
+  // `babelify`. We don't have `babelify` installed because we are
+  // testing using latest Chrome and thus don't need any transpilation.
+  // Let's remove the browserify config from the package and force
+  // browserify to use our config instead.
+  if (pkg.name === 'async') {
+    delete pkg.browserify;
+  }
+  return pkg;
+};


### PR DESCRIPTION
Add `packageFilter` to handle buggy `async` browserify config.

See the downstream build failure reported for https://github.com/strongloop/loopback/pull/4262 in https://cis-jenkins.swg-devops.com/job/ds/job/loopback-boot%7Emaster/43/console.