### PR TITLE
1.x: Provide scriptExtensions option

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -40,9 +40,18 @@ module.exports = function compile(options) {
     ConfigLoader.loadDataSources(dsRootDir, env);
   assertIsValidConfig('data source', dataSourcesConfig);
 
+  // backport https://github.com/strongloop/loopback-boot/pull/240/
+  var scriptExtensions = options.scriptExtensions ||
+    Object.keys(require.extensions);
+  if (!Array.isArray(scriptExtensions) || !scriptExtensions.length) {
+    scriptExtensions = ['.js', '.json', '.node'];
+  }
+
   // require directories
-  var modelsScripts = findScripts(path.join(modelsRootDir, 'models'));
-  var bootScripts = findScripts(path.join(appRootDir, 'boot'));
+  var modelsScripts = findScripts(path.join(modelsRootDir, 'models'),
+    scriptExtensions);
+  var bootScripts = findScripts(path.join(appRootDir, 'boot'),
+    scriptExtensions);
 
   // When executor passes the instruction to loopback methods,
   // loopback modifies the data. Since we are loading the data using `require`,
@@ -73,7 +82,7 @@ function assertIsValidConfig(name, config) {
  * @private
  */
 
-function findScripts(dir) {
+function findScripts(dir, scriptExtensions) {
   assert(dir, 'cannot require directory contents without directory name');
 
   var files = tryReadDir(dir);
@@ -105,10 +114,11 @@ function findScripts(dir) {
 
     // only require files supported by require.extensions (.txt .md etc.)
     if (stats.isFile()) {
-      if (ext in require.extensions)
+      if (scriptExtensions.indexOf(ext) !== -1) {
         results.push(filepath);
-      else
+      } else {
         debug('Skipping file %s - unknown extension', filepath);
+      }
     } else {
       try {
         path.join(require.resolve(filepath));


### PR DESCRIPTION
Backport of https://github.com/strongloop/loopback-boot/pull/240 for compatibility with Jest. No user-facing changes required in most cases.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-boot) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
